### PR TITLE
Disabled hover style when parent node  is expanded

### DIFF
--- a/src/client/features/view/cy/events/hover.js
+++ b/src/client/features/view/cy/events/hover.js
@@ -94,15 +94,9 @@ const baseEdgeHoverStyle = {
 };
 
 const bindHover = (cy) => {
-  cy.on('mouseover', 'node[class !="compartment"]', function (evt) {
+  cy.on('mouseover', 'node[class!="compartment"]', function (evt) {
     const node = evt.target;
     const currZoom = cy.zoom();
-    const isCollapsed = node.data('compoundCollapse.collapsed');
-    const hasChildren = (node.children().length > 0);
-
-    if(hasChildren && !(isCollapsed)){
-      return;
-    }
 
     const { fontSize, outlineWidth, arrowScale, edgeWidth } = dynamicScalingfactors(currZoom);
 
@@ -130,6 +124,7 @@ const bindHover = (cy) => {
   cy.on('mouseout', 'node[class!="compartment"]', function (evt) {
     const node = evt.target;
     const neighborhood = node.neighborhood();
+
     removeHoverStyle(cy, neighborhood.nodes());
     removeHoverStyle(cy, node);
     removeHoverStyle(cy, neighborhood.edges());
@@ -138,6 +133,7 @@ const bindHover = (cy) => {
   cy.on('mouseover', 'edge', function (evt) {
     const edge = evt.target;
     const currZoom = cy.zoom();
+
     const { fontSize, outlineWidth, arrowScale, edgeWidth } = dynamicScalingfactors(currZoom);
 
     const edgeHoverStyle = extend({}, baseEdgeHoverStyle, {

--- a/src/client/features/view/cy/events/hover.js
+++ b/src/client/features/view/cy/events/hover.js
@@ -94,9 +94,15 @@ const baseEdgeHoverStyle = {
 };
 
 const bindHover = (cy) => {
-  cy.on('mouseover', 'node[class!="compartment"]', function (evt) {
+  cy.on('mouseover', 'node[class !="compartment"]', function (evt) {
     const node = evt.target;
     const currZoom = cy.zoom();
+    const isCollapsed = node.data('compoundCollapse.collapsed');
+    const hasChildren = (node.children().length > 0);
+
+    if(hasChildren && !(isCollapsed)){
+      return;
+    }
 
     const { fontSize, outlineWidth, arrowScale, edgeWidth } = dynamicScalingfactors(currZoom);
 
@@ -124,7 +130,6 @@ const bindHover = (cy) => {
   cy.on('mouseout', 'node[class!="compartment"]', function (evt) {
     const node = evt.target;
     const neighborhood = node.neighborhood();
-
     removeHoverStyle(cy, neighborhood.nodes());
     removeHoverStyle(cy, node);
     removeHoverStyle(cy, neighborhood.edges());
@@ -133,7 +138,6 @@ const bindHover = (cy) => {
   cy.on('mouseover', 'edge', function (evt) {
     const edge = evt.target;
     const currZoom = cy.zoom();
-
     const { fontSize, outlineWidth, arrowScale, edgeWidth } = dynamicScalingfactors(currZoom);
 
     const edgeHoverStyle = extend({}, baseEdgeHoverStyle, {

--- a/src/client/features/view/cy/events/hover.js
+++ b/src/client/features/view/cy/events/hover.js
@@ -98,6 +98,8 @@ const bindHover = (cy) => {
     const node = evt.target;
     const currZoom = cy.zoom();
 
+    if (node.isParent() && node.isExpanded()) { return; }
+
     const { fontSize, outlineWidth, arrowScale, edgeWidth } = dynamicScalingfactors(currZoom);
 
     node.neighborhood().nodes().union(node).forEach((node) => {


### PR DESCRIPTION
#69 - I implemented a quick fix to the hover issue, which simply prevents the event from applying the hover style to a parent if its expanded. 