### PR TITLE
Implemented tooltip and search suggestions 

### DIFF
--- a/src/client/features/view/components/graph/index.js
+++ b/src/client/features/view/components/graph/index.js
@@ -52,6 +52,7 @@ class Graph extends React.Component {
     //toolTipCreator.bindTippyToElements(cy);
     this.props.updateRenderStatus(true);
     this.setState({graphRendered: true});
+
   }
 
   render() {

--- a/src/client/features/view/components/menu/search.js
+++ b/src/client/features/view/components/menu/search.js
@@ -72,11 +72,13 @@ function searchNodes(query, cy) {
   //Define highlighting style
   const searchStyle = {
     'overlay-color': 'yellow',
+    'overlay-padding' : 0,
     'overlay-opacity': 0.5
   };
 
   const baseStyle = {
     'overlay-color': '#000',
+    'overlay-padding' : 0,
     'overlay-opacity': '0'
   };
 

--- a/src/client/features/view/components/tooltips/formatArray.js
+++ b/src/client/features/view/components/tooltips/formatArray.js
@@ -10,6 +10,17 @@ function collectionToBottom(data, criteriaList) {
   return notMatched.concat(_.sortBy(matched, pair => criteriaList.indexOf(pair[0])));
 }
 
+//Push a collection of elements to the top of the list
+//Takes in a list of id's and pushes all matching items to the bottom of the list
+//Requires a valid list of ids
+function collectionToTop(data, criteriaList) {
+  if(!(data)) {return [];}
+  const matched = data.filter(pair => criteriaList.includes(pair[0]));
+  const notMatched = _.difference(data, matched);
+  return _.sortBy(matched, pair => criteriaList.indexOf(pair[0])).concat(notMatched);
+}
+
 module.exports = {
-  collectionToBottom
+  collectionToBottom,
+  collectionToTop
 };

--- a/src/client/features/view/components/tooltips/generateContent.js
+++ b/src/client/features/view/components/tooltips/generateContent.js
@@ -8,11 +8,6 @@ const config = require('../../config');
 const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Approved Name: ');
 const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
 
-/*
-const displayNameHandler = (pair) => makeTooltipItem(pair[1], 'Display Name: ');
-const displayNameHandlerTrim = (pair) => displayNameHandler(pair);
-*/
-
 const nameHandlerTrim = (pair) => {
   let shortArray = filterChemicalFormulas(trimValue(pair[1], 3));
   return h('div.fake-paragraph', [
@@ -77,8 +72,6 @@ const defaultHandler = (pair) => {
 const metaDataKeyMap = new Map()
   .set('Standard Name', standardNameHandler)
   .set('Standard NameTrim', standardNameHandlerTrim)
-  //.set('Display Name', displayNameHandler)
-  //.set('Display NameTrim', displayNameHandlerTrim)
   .set('Type', typeHandler)
   .set('TypeTrim', typeHandler)
   .set('Names', nameHandler)

--- a/src/client/features/view/components/tooltips/generateContent.js
+++ b/src/client/features/view/components/tooltips/generateContent.js
@@ -12,14 +12,14 @@ const displayNameHandlerTrim = (pair) => displayNameHandler(pair);
 const nameHandlerTrim = (pair) => {
   let shortArray = filterChemicalFormulas(trimValue(pair[1], 3));
   return h('div.fake-paragraph', [
-    h('div.field-name','Synonyms:'),
+    h('div.field-name', 'Synonyms:'),
     valueToHtml(shortArray, true)
   ]);
 };
 const nameHandler = (pair) => {
   let shortArray = filterChemicalFormulas(pair[1]);
   return h('div.fake-paragraph', [
-    h('div.field-name','Synonyms:'),
+    h('div.field-name', 'Synonyms:'),
     valueToHtml(shortArray, true)
   ]);
 };
@@ -30,7 +30,7 @@ const dataSourceHandler = (pair) => {
   let source = pair[1].replace('http://pathwaycommons.org/pc2/', '');
   let link = generateDataSourceLink(source, 'Data Source: ');
   return h('div.fake-paragraph', link);
-};*/ 
+};*/
 
 const databaseHandlerTrim = (pair) => {
   if (pair[1].length < 1) { return h('div.error'); }
@@ -54,7 +54,7 @@ const typeHandler = (pair) => {
 const defaultHandler = (pair) => {
   let key = pair[0];
   let isCommaSeparated = true;
-  if (key === 'Comment') { 
+  if (key === 'Comment') {
     key = 'Comments';
     isCommaSeparated = false;
   }
@@ -81,30 +81,30 @@ const metaDataKeyMap = new Map()
 //Optional trim parameter indicates if the data presented should be trimmed to a reasonable length
 //Data Pair -> HTML
 function parseMetadata(pair, trim = true) {
-  const doNotRender = ['Data Source', 'Data SourceTrim'];
-  let key = pair[0];
+    const doNotRender = ['Data Source', 'Data SourceTrim'];
+    let key = pair[0];
 
-  //Use the trim function if trim is applied
-  if (trim){
-    key += "Trim";
-  }
+    //Use the trim function if trim is applied
+    if (trim) {
+      key += "Trim";
+    }
 
-  let handler = metaDataKeyMap.get(key);
-  if (handler) {
-    return handler(pair);
-  }
-  else if (!(trim) && !doNotRender.includes(key)) {
-    return defaultHandler(pair);
-  }
-  else {
-    return h('div.error');
-  }
+    let handler = metaDataKeyMap.get(key);
+    if (handler) {
+      return handler(pair);
+    }
+    else if (!(trim) && !doNotRender.includes(key)) {
+      return defaultHandler(pair);
+    }
+    else {
+      return h('div.error');
+    }
 }
 
 //Trim a value to n terms
 //String or Array -> Array
-function trimValue(value, n){
-  if(typeof value === 'string'){
+function trimValue(value, n) {
+  if (typeof value === 'string') {
     return value;
   }
   else {
@@ -123,7 +123,7 @@ function valueToHtml(value, isCommaSeparated = false) {
     return h('div.tooltip-value', value);
   }
   //Array Comma Separated -> HTML
-  else if (value instanceof Array && isCommaSeparated){
+  else if (value instanceof Array && isCommaSeparated) {
     //Add a comma to each value
     value = value.map(value => h('div.tooltip-comma-item', value + ','));
 
@@ -294,14 +294,15 @@ function generateDatabaseList(sortedArray, trim) {
   let renderValue = sortedArray.map(item => generateIdList(item, trim), this);
 
   //If in expansion mode, append list styling
-  if(!trim) {
-    renderValue =  h('div.wrap-text', h('ul.db-list', renderValue));
+  if (!trim) {
+    renderValue = h('div.wrap-text', h('ul.db-list', renderValue));
   }
 
-  return h('div.fake-paragraph',[h('div.span-field-name', 'Database References:'), renderValue]);
+  return h('div.fake-paragraph', [h('div.span-field-name', 'Database References:'), renderValue]);
 }
 
 module.exports = {
   parseMetadata,
-  noDataWarning
+  noDataWarning,
+  sortByDatabaseId
 };

--- a/src/client/features/view/components/tooltips/generateContent.js
+++ b/src/client/features/view/components/tooltips/generateContent.js
@@ -9,20 +9,22 @@ const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
 const displayNameHandler = (pair) => makeTooltipItem(pair[1], 'Display Name: ');
 const displayNameHandlerTrim = (pair) => displayNameHandler(pair);
 const nameHandlerTrim = (pair) => {
-  let shortArray = filterChemicalFormulas(pair[1].slice(0, 3));
-  return h('div.fake-paragraph', [h('div.field-name', 'Synonyms: '), h('div.tooltip-value', shortArray.toString())]);
+  let shortArray = filterChemicalFormulas(trimValue(pair[1], 3));
+  return h('div.fake-paragraph', [h('div.field-name', 'Synonyms: '), valueToHtml(shortArray, true)]);
 };
 const nameHandler = (pair) => {
   let shortArray = filterChemicalFormulas(pair[1]);
-  return h('div.fake-paragraph', [h('div.field-name', 'Synonyms: '), valueToHtml(shortArray)]);
+  return h('div.fake-paragraph', [h('div.field-name', 'Synonyms: '), valueToHtml(shortArray, true)]);
 };
 
 //Handle database related fields
+/*
 const dataSourceHandler = (pair) => {
   let source = pair[1].replace('http://pathwaycommons.org/pc2/', '');
   let link = generateDataSourceLink(source, 'Data Source: ');
   return h('div.fake-paragraph', link);
-};
+};*/ 
+
 const databaseHandlerTrim = (pair) => {
   if (pair[1].length < 1) { return h('div.error'); }
   return generateDatabaseList(sortByDatabaseId(pair[1]), true);
@@ -56,7 +58,6 @@ const metaDataKeyMap = new Map()
   .set('Standard NameTrim', standardNameHandlerTrim)
   .set('Display Name', displayNameHandler)
   .set('Display NameTrim', displayNameHandlerTrim)
-  .set('Data Source', dataSourceHandler)
   .set('Type', typeHandler)
   .set('Names', nameHandler)
   .set('NamesTrim', nameHandlerTrim)
@@ -87,12 +88,36 @@ function parseMetadata(pair, trim = true) {
   }
 }
 
-//Create a HTML Element for a given value
+//Trim a value to n terms
+//String or Array -> Array
+function trimValue(value, n){
+  if(typeof value === 'string'){
+    return value;
+  }
+  else {
+    return value.slice(0, n);
+  }
+}
+
+//Create a HTML Element for a given value\
+//Note : Optional isCommaSeparated parameter indicates if the list should be
+//       printed as a comma separated list. 
+//Requires a populated array
 //Anything -> HTML
-function valueToHtml(value) {
+function valueToHtml(value, isCommaSeparated = false) {
   //String -> HTML
   if (typeof value === 'string') {
     return h('div.tooltip-value', value);
+  }
+  else if (value instanceof Array && isCommaSeparated){
+    //Add a comma to each value
+    value = value.map(value => h('div.tooltip-comma-item', value + ','));
+
+    //Remove comma from the last value
+    let end = value.length - 1;
+    value[end].innerHTML = value[end].innerHTML.slice(0, -1);
+
+    return ('div.tooltip-value', value);
   }
   //Array Length 1 -> HTML
   else if (value instanceof Array && value.length === 1) {

--- a/src/client/features/view/components/tooltips/metadataTip.js
+++ b/src/client/features/view/components/tooltips/metadataTip.js
@@ -4,6 +4,7 @@ const tippy = require('tippy.js');
 const config = require('../../config');
 const generate = require('./generateContent');
 const formatArray = require('./formatArray');
+const publications = require('./publications');
 
 //Manage the creation and display of metadata HTML content
 //Requires a valid name, cytoscape element, and parsedMetadata array
@@ -30,7 +31,7 @@ class MetadataTip {
       //Generate HTML
       let tooltipHTML = this.generateToolTip(callback);
       let expandedHTML = this.generateExtendedToolTip(callback);
-      
+
       //Create tippy object
       let refObject = this.cyElement.popperRef();
       tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true });
@@ -65,6 +66,8 @@ class MetadataTip {
     //Order the data array
     let data = formatArray.collectionToTop(this.data,['Type','Display Name', 'Standard Name', 'Names', 'Database IDs']);
     data = formatArray.collectionToBottom(data, ['Comment']);
+
+    publications(data); 
 
     if (!(data) || data.length === 0) {
       return generate.noDataWarning(this.name);

--- a/src/client/features/view/components/tooltips/metadataTip.js
+++ b/src/client/features/view/components/tooltips/metadataTip.js
@@ -76,7 +76,7 @@ class MetadataTip {
     if (!(this.data)) { this.data = []; }
     return h('div.tooltip-image', [
       h('div.tooltip-heading', this.name),
-      h('div.tooltip-internal', h('div', (data).map(item => generate.parseMetadata(item, true), this))),
+      h('div.tooltip-internal', h('div', (data).map(item => generate.parseMetadata(item, true)), this)),
       h('div.tooltip-buttons',
         [
           h('div.tooltip-button-container',

--- a/src/client/features/view/components/tooltips/metadataTip.js
+++ b/src/client/features/view/components/tooltips/metadataTip.js
@@ -63,7 +63,8 @@ class MetadataTip {
   //Generate HTML Elements for tooltips
   generateToolTip() {
     //Order the data array
-    let data = formatArray.collectionToBottom(this.data, ['Database IDs', 'Comment']);
+    let data = formatArray.collectionToTop(this.data,['Display Name', 'Standard Name', 'Names', 'Type', 'Database IDs']);
+    data = formatArray.collectionToBottom(data, ['Comment']);
 
     if (!(data) || data.length === 0) {
       return generate.noDataWarning(this.name);
@@ -92,7 +93,8 @@ class MetadataTip {
   //Generate HTML Elements for the side bar
   generateExtendedToolTip() {
     //Order the data array
-    let data = formatArray.collectionToBottom(this.data, ['Database IDs', 'Comment']);
+    let data = formatArray.collectionToTop(this.data,['Display Name', 'Standard Name', 'Names', 'Type', 'Database IDs']);
+    data = formatArray.collectionToBottom(data, ['Comment']);
     if (!(data)) data = [];
 
     //Ensure name is not blank

--- a/src/client/features/view/components/tooltips/metadataTip.js
+++ b/src/client/features/view/components/tooltips/metadataTip.js
@@ -63,7 +63,7 @@ class MetadataTip {
   //Generate HTML Elements for tooltips
   generateToolTip() {
     //Order the data array
-    let data = formatArray.collectionToTop(this.data,['Display Name', 'Standard Name', 'Names', 'Type', 'Database IDs']);
+    let data = formatArray.collectionToTop(this.data,['Type','Display Name', 'Standard Name', 'Names', 'Database IDs']);
     data = formatArray.collectionToBottom(data, ['Comment']);
 
     if (!(data) || data.length === 0) {
@@ -93,7 +93,7 @@ class MetadataTip {
   //Generate HTML Elements for the side bar
   generateExtendedToolTip() {
     //Order the data array
-    let data = formatArray.collectionToTop(this.data,['Display Name', 'Standard Name', 'Names', 'Type', 'Database IDs']);
+    let data = formatArray.collectionToTop(this.data,['Type','Display Name', 'Standard Name', 'Names', 'Database IDs']);
     data = formatArray.collectionToBottom(data, ['Comment']);
     if (!(data)) data = [];
 

--- a/src/client/features/view/components/tooltips/publications.js
+++ b/src/client/features/view/components/tooltips/publications.js
@@ -1,0 +1,55 @@
+const _ = require('lodash');
+const generate = require('./generateContent');
+
+//Fetch Publications XML from PubMed
+function fetchPubMedPublication(id) {
+  const options = {
+    method: 'GET',
+    'Content-Type': 'application/json',
+    'Accept': 'application/json'
+  };
+  const urlPrefix = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json&id=';
+  return fetch(urlPrefix + id.toString(), options).then(res => res.json());
+}
+
+
+//Process an array of publication data into human readable links
+//Array -> HTML
+function processPublicationData(data){
+  const result = data.result
+  if(!(result)) { return null;}
+  const uids = result.uids;
+
+  //Loop through a database ids
+  let extractedData = uids.map(uid => {
+    const publicationData = result[uid];
+    return {
+      title : publicationData.title,
+      authors : publicationData.authors
+    };
+  });
+
+  console.log(extractedData);
+}
+
+//Get publication titles and references
+//Metadata -> HTML
+function getPublications(data) {
+  //Get Database Ids
+  const databaseIds = data.filter(pair => pair[0] == 'Database IDs')[0];
+  if (!(databaseIds)) { return null; }
+
+  //Get PubMed References
+  const sorted = generate.sortByDatabaseId(databaseIds[1]);
+  const pubMedReferences = sorted.filter(item => item.database.toUpperCase() === 'PUBMED');
+  if (!(pubMedReferences) || pubMedReferences.length === 0) { return null; }
+
+  const pubMedIds = pubMedReferences[0].ids;
+  let promiseArray = [];
+
+  //Get publication data in bulk and process publication data
+  fetchPubMedPublication(pubMedIds).then(data => processPublicationData(data));
+}
+ 
+
+module.exports = getPublications;

--- a/src/client/features/view/config.js
+++ b/src/client/features/view/config.js
@@ -23,8 +23,15 @@ const databases = [
   ['CAS', 'http://identifiers.org/cas/', '']
 ];
 
+const publicationsURL = 'http://identifiers.org/pubmed/';
+const tooltipOrder = ['Type', 'Display Name', 'Standard Name', 'Names', 'Database IDs', 'Publications'];
+const tooltipReverseOrder = ['Comment'];
+
 module.exports = {
-  databases
+  databases,
+  publicationsURL,
+  tooltipOrder,
+  tooltipReverseOrder
 }
 
 /*

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -157,6 +157,34 @@
   width: 100%;
 }
 
+.publication-list{
+  line-height: 1.2em;
+}
+
+.publication-item {
+  word-wrap: break-word;
+  line-height: 1.2em;
+}
+
+.publication-link {
+  color: var(--link);
+  margin: 2px;
+  font-weight: lighter;
+}
+
+.publication-subinfo {
+  padding-top: 6px;
+}
+
+.publication-inline{
+  display: inline; 
+}
+
+.publication-divider{
+  font-size: 1.19em;
+  padding: 2px;
+}
+
 .db-list {
   line-height: 0.2em;
 }

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -70,8 +70,18 @@
   font-size: 0.75em;
 }
 
+.db-names-list{
+  display: inline;
+}
+
 .field-name {
-  margin: 2px;
+  display: inline-block;
+  font-weight: bold;
+}
+
+
+
+.span-field-name {
   display: inline-block;
   font-weight: bold;
 }
@@ -83,7 +93,10 @@
 }
 
 .tooltip-comma-item {
+  padding: 2px;
+  display: inline;
 }
+
 
 .tooltip-comment {
   margin: 3px;
@@ -99,9 +112,10 @@
 
 .db-link-single-ref {
   text-decoration: underline;
-  margin: 3px;
-  display: inline-block;
+  margin: 2px;
+  display: inline;
   color: var(--link);
+  line-height: 1.5;
 }
 
 .db-no-link-single-ref {
@@ -110,10 +124,13 @@
   color: black;
 }
 
+.fake-spacer {
+  display: inline-block;
+}
 
 .fake-paragraph {
   word-wrap: break-word;
-  margin: 6px;
+  margin: 3px;
   padding: 2px;
 }
 

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -82,6 +82,9 @@
   word-wrap: break-word;
 }
 
+.tooltip-comma-item {
+}
+
 .tooltip-comment {
   margin: 3px;
   display: inline-block;


### PR DESCRIPTION
### Tooltip 

- #187 -  Fixed tooltip ordering. All the tooltips will always maintain the order of the values. 
- #180 -  Replaced Publication Ids with publication names
 ![screen shot 2017-11-20 at 10 38 23 am](https://user-images.githubusercontent.com/1313810/33030233-cecb55f2-cde8-11e7-8fd1-4c0c87cb38cf.png)

- #189 - Removed Datasource/Display Name from the tooltip
- #213 - Database References and field-values have been formatted as comma separated lists

### Search 
#212 - Set the Overlay Padding to 0 