### PR TITLE
Node Event Binding Changes and Tooltip alignment changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cytoscape-cola": "^2.0.0",
     "cytoscape-compound-collapse": "git+https://github.com/d2fong/cytoscape.js-compound-collapse.git",
     "cytoscape-cose-bilkent": "git+https://github.com/d2fong/cytoscape.js-cose-bilkent.git#simple-label-dimensions",
+    "cytoscape-cxtmenu": "^2.10.3",
     "cytoscape-dagre": "^2.0.0",
     "cytoscape-fisheye": "git+https://github.com/d2fong/cytoscape.js-fisheye.git",
     "cytoscape-klay": "^3.0.0",

--- a/src/client/cytoscape-extensions.js
+++ b/src/client/cytoscape-extensions.js
@@ -13,7 +13,6 @@ const fisheye = require('cytoscape-fisheye');
 //Tooltips
 const popper = require('cytoscape-popper');
 
-
 module.exports = () => {
   cytoscape.use(cola);
   cytoscape.use(klay, klayjs);

--- a/src/client/features/view/components/tooltips/metadataTip.js
+++ b/src/client/features/view/components/tooltips/metadataTip.js
@@ -37,8 +37,8 @@ class MetadataTip {
 
         //Create tippy object
         let refObject = this.cyElement.popperRef();
-        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual' });
-        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual' });
+        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false });
+        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false  });
 
         //Resolve Reference issues
         tooltip.selector.dim = refObject.dim;
@@ -101,6 +101,10 @@ class MetadataTip {
     let data = formatArray.collectionToTop(this.data, config.tooltipOrder);
     data = formatArray.collectionToBottom(data, config.tooltipReverseOrder);
     if (!(data)) data = [];
+
+    if (!(data) || data.length === 0) {
+      return generate.noDataWarning(this.name);
+    }
 
     //Ensure name is not blank
     this.validateName();

--- a/src/client/features/view/components/tooltips/metadataTip.js
+++ b/src/client/features/view/components/tooltips/metadataTip.js
@@ -37,8 +37,8 @@ class MetadataTip {
 
         //Create tippy object
         let refObject = this.cyElement.popperRef();
-        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false });
-        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false  });
+        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true });
+        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true  });
 
         //Resolve Reference issues
         tooltip.selector.dim = refObject.dim;

--- a/src/client/features/view/cy/events/click.js
+++ b/src/client/features/view/cy/events/click.js
@@ -1,23 +1,80 @@
-const MetadataTip = require('../../components/tooltips/metadataTip');
-
-const bindClick = (cy, callback) => {
-  //Tippy JS Events
-  //Binding actions (Try/Catch blocks re only for quick demo purposes)
-  //Bind right click event to tippy.show()
-  cy.on('cxttap', 'node', function (evt) {
-      let data = evt.target.data();
-      let name = data.label;
-      let cy = evt.cy;
-
-      //Create or get tooltip HTML object
-      let html = evt.target.scratch('_tooltip');
-      if(!(html)){
-        html = new MetadataTip(name, data, evt.target);
-        evt.target.scratch('_tooltip', html);
-      }
-
-      html.show(cy, callback);
+//Hide all Tooltips
+//Requires a valid cytoscape element
+const hideTooltips = (cy) => {
+  cy.elements().each(function (element) {
+    var tempElement = element.scratch('_tooltip');
+    if (tempElement && tempElement.isVisible()) { tempElement.hide(); }
   });
+  incrementClicks(cy, true);
+};
+
+//Increment click counter and return new counter value
+//Requires a valid cytoscape element
+//Note : Optional reset parameter set the counter to 0
+const incrementClicks = (cy, reset) => {
+  if (reset){
+    cy.scratch('_clicks', 0);
+    return 0;
+  }
+  else {
+    let clicks = cy.scratch('_clicks');
+    if (Number.isInteger(clicks)) { clicks++; }
+    else clicks = 0;
+    cy.scratch('_clicks', clicks);
+    return clicks;
+  }
+};
+
+const bindClick = (cy) => {
+  //Click Handler
+  //Manage Single and Double Click Events
+  cy.on('tap', evt => {
+    const cy = evt.cy;
+    const target = evt.target; 
+    const timeout = 300;
+
+    //Click executed on core
+    //Hide all tool tips
+    if (evt.target == evt.cy) {
+      hideTooltips(cy);
+      return;
+    }
+
+    //Hide tooltip if tooltip is visible 
+    var tempElement = target.scratch('_tooltip');
+    if (tempElement && tempElement.isVisible()) {
+      tempElement.hide();
+      incrementClicks(cy, true);
+      return;
+    }
+
+    let clicks = incrementClicks(cy);
+
+    //Pause and wait for any additional clicks
+    if (clicks == 1) {
+      setTimeout(() => {
+        clicks = cy.scratch('_clicks');
+
+        //Display Tooltip
+        if (clicks == 1) {
+          evt.target.emit('showTooltip');
+        }
+        //Expand Collapse
+        else if (clicks != 0) {
+          evt.target.emit('expandCollapse');
+        }
+
+        //Reset clicks
+        incrementClicks(cy, true);
+
+      }, timeout);
+    }
+  });
+
+  //Hide Tooltips on various graph movements
+  cy.on('drag', evt => hideTooltips(evt.cy));
+  cy.on('pan', evt => hideTooltips(evt.cy));
+  cy.on('zoom', evt => hideTooltips(evt.cy));
 };
 
 module.exports = bindClick;

--- a/src/client/features/view/cy/events/expandCollapse.js
+++ b/src/client/features/view/cy/events/expandCollapse.js
@@ -3,7 +3,7 @@ const siblings = (node) => {
 };
 
 const bindExpandCollapse = (cy) => {
-  cy.on('tap', 'node[class="complex"], node[class="complex multimer"]', function (evt) {
+  cy.on('expandCollapse', 'node[class="complex"], node[class="complex multimer"]', function (evt) {
     evt.preventDefault();
     const node = evt.target;
     if (node.isCollapsed()) {

--- a/src/client/features/view/cy/events/index.js
+++ b/src/client/features/view/cy/events/index.js
@@ -1,11 +1,13 @@
 const bindHover = require('./hover');
 const bindExpandCollapse = require('./expandCollapse');
 const bindClick = require('./click');
+const bindShowTooltip = require('./showTooltip');
 
 const bindEvents = (cy, callback) => {
   bindHover(cy);
   bindExpandCollapse(cy);
   bindClick(cy, callback);
+  bindShowTooltip(cy);
 };
 
 module.exports = bindEvents;

--- a/src/client/features/view/cy/events/showTooltip.js
+++ b/src/client/features/view/cy/events/showTooltip.js
@@ -1,0 +1,20 @@
+const MetadataTip = require('../../components/tooltips/metadataTip');
+
+const bindShowTooltip = (cy) => {
+  cy.on('showTooltip', 'node', function (evt) {
+    let data = evt.target.data();
+    let name = data.label;
+    let cy = evt.cy;
+
+    //Create or get tooltip HTML object
+    let html = evt.target.scratch('_tooltip');
+    if (!(html)) {
+      html = new MetadataTip(name, data, evt.target);
+      evt.target.scratch('_tooltip', html);
+    }
+
+    html.show(cy);
+  });
+};
+
+module.exports = bindShowTooltip; 


### PR DESCRIPTION
### Node Event 
- #215 - Double-click has been mapped to expand/collapse
- #215 - Single click now summons the tooltip
- #215 - Tooltip does not appear when a user drags the node around
- #176 - Tooltip now works in Firefox 

### Alignment changes
- #224 - Alignment issue was related to the popper.js extension and has been resolved. Changes will be applied when the Popper PR is merged cytoscape/cytoscape.js-popper#10 
- Tooltip also now resizes based on zoom level. 
