### PR TITLE
Fixes search bug on some browsers where scrollbar always appears beneath tabs.

### DIFF
--- a/src/styles/features/search.css
+++ b/src/styles/features/search.css
@@ -114,7 +114,6 @@
   padding-top: 10px;
   display: flex;
   flex-direction: row;
-  overflow-x: scroll;
 }
 
 .search-option-item-container {
@@ -274,5 +273,9 @@
 
   .search-list-container {
     padding-left: 10px;
+  }
+
+  .search-tabs {
+    overflow-x: scroll;
   }
 }


### PR DESCRIPTION
This bug appears on Harsh and Geoff's browsers but not on mine for some reason. This should fix it.