### PR TITLE
Truncate long complex names when collapsed

### DIFF
--- a/src/client/common/cy/stylesheet.js
+++ b/src/client/common/cy/stylesheet.js
@@ -27,7 +27,8 @@ const stylesheet = sbgnStyleSheet(cytoscape)
 .selector('.compoundcollapse-collapsed-node')
 .css({
   'font-size': 20,
-  'text-max-width': 175
+  'text-max-width': 175,
+  'text-wrap': 'ellipsis'
 })
 .selector('edge')
 .css({


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28417535/33185394-4ba92e0a-d050-11e7-81ce-a2c87daccce8.png)

closes #195