### PR TITLE
Update to beta version of uglify JS to support ES6 syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "rimraf": "^2.6.2",
     "stylelint": "^8.2.0",
     "stylelint-config-standard": "^17.0.0",
-    "uglifyjs-webpack-plugin": "^0.4.6",
+    "uglifyjs-webpack-plugin": "^1.0.0-beta.1",
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^2.9.0"
   },


### PR DESCRIPTION
Currently the development build on Jenkins fails because `uglify-js` doesn't support some ES6 syntax. Updating the uglify version to the beta fixes the production build.