### PR TITLE
Reverts port and uglify changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "rimraf": "^2.6.2",
     "stylelint": "^8.2.0",
     "stylelint-config-standard": "^17.0.0",
-    "uglifyjs-webpack-plugin": "^1.0.0-beta.1",
+    "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^2.9.0"
   },

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -2,7 +2,7 @@ const process = require('process');
 const _ = require('lodash');
 
 let defaults = {
-  PORT: 2000
+  PORT: 3000
 };
 
 let envVars = _.pick( process.env, Object.keys( defaults ) );


### PR DESCRIPTION
Sets uglify version back to 0.4.6 (#256), and resets port to 3000 (#255).

Should handle #264 as well.