### PR TITLE
Tooltip Revision 3 

### DIFF
--- a/src/client/common/cy/events/click.js
+++ b/src/client/common/cy/events/click.js
@@ -3,7 +3,7 @@
 const hideTooltips = (cy) => {
   cy.elements().each(function (element) {
     var tempElement = element.scratch('_tooltip');
-    if (tempElement && tempElement.isVisible()) { tempElement.hide(); }
+    if (tempElement) { tempElement.hide(); }
   });
   incrementClicks(cy, true);
 };

--- a/src/client/common/tooltips/config.js
+++ b/src/client/common/tooltips/config.js
@@ -27,11 +27,16 @@ const publicationsURL = 'http://identifiers.org/pubmed/';
 const tooltipOrder = ['Type', 'Display Name', 'Standard Name', 'Names', 'Database IDs', 'Publications'];
 const tooltipReverseOrder = ['Comment'];
 
+const defaultEntryLimit = 3;
+const commentEntryLimit = 1;
+
 module.exports = {
   databases,
   publicationsURL,
   tooltipOrder,
-  tooltipReverseOrder
+  tooltipReverseOrder,
+  defaultEntryLimit,
+  commentEntryLimit
 };
 
 /*

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -5,7 +5,7 @@ const config = require('./config');
 
 
 //Handle name related metadata fields
-const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Approved Name: ');
+const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Name: ');
 const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
 
 const nameHandlerTrim = (pair) => {
@@ -351,7 +351,7 @@ function generateDatabaseList(sortedArray, trim) {
     renderValue = h('div.wrap-text', h('ul.db-list', renderValue));
   }
 
-  return h('div.fake-paragraph', [h('div.span-field-name', 'Database References:'), renderValue]);
+  return h('div.fake-paragraph', [h('div.span-field-name', 'Links :'), renderValue]);
 }
 
 //Replace any instances of Replaced 

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -41,12 +41,12 @@ const dataSourceHandler = (pair) => {
 };*/
 
 const databaseHandlerTrim = (pair, expansionFunction) => {
-  const expansionLink = h('div.more-link', { onClick: () => expansionFunction(pair[0]) }, 'more »');
+  const expansionLink = h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »');
   if (pair[1].length < 1) { return h('div.error'); }
   return generateDatabaseList(sortByDatabaseId(pair[1]), true, expansionLink);
 };
 const databaseHandler = (pair, expansionFunction) => {
-  const expansionLink = h('div.more-link', { onClick: () => expansionFunction(pair[0]) }, '« less');
+  const expansionLink = h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, '« less');
   if (pair[1].length < 1) { return h('div.error'); }
   return generateDatabaseList(sortByDatabaseId(pair[1]), false, expansionLink);
 
@@ -74,7 +74,7 @@ const commentHandler = (pair, expansionFunction) => {
   if (comments.length < 1) { return h('div.error'); }
 
   //Generate expansion link
-  let expansionLink = h('div.more-link', { onClick: () => expansionFunction(pair[0]) }, '« less');
+  let expansionLink = h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, '« less');
   comments[comments.length - 1] = [comments[comments.length - 1], expansionLink];
 
   return h('div.fake-paragraph', [h('div.field-name', 'Comments' + ': '), valueToHtml(comments, false)]);
@@ -89,7 +89,7 @@ const commentHandlerTrim = (pair, expansionFunction) => {
 
   //Generate expansion link
   let expansionLink = comments.length > commentEntryLimit ?
-    h('div.more-link', { onClick: () => { console.log(expansionFunction, pair); expansionFunction(pair[0]);} }, 'more »') : null;
+    h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »') : null;
   if (expansionLink) { shortArray[commentEntryLimit - 1] = [shortArray[commentEntryLimit - 1], expansionLink]; }
 
   return h('div.fake-paragraph', [h('div.field-name', 'Comments' + ': '), valueToHtml(shortArray, false)]);
@@ -380,14 +380,17 @@ function generateDatabaseList(sortedArray, trim, expansionLink) {
   //Generate list
   let renderValue = sortedArray.map(item => generateIdList(item, trim), this);
 
+   //Append expansion link to render value if one exists
+   if (expansionLink && hasMultipleIds && trim) {
+    renderValue = [renderValue, expansionLink];
+  }
+  else if (expansionLink && hasMultipleIds){
+    renderValue.push(h('li.db-item', expansionLink));
+  }
+
   //If in expansion mode, append list styling
   if (!trim) {
     renderValue = h('div.wrap-text', h('ul.db-list', renderValue));
-  }
-
-  //Append expansion link to render value if one exists
-  if (expansionLink && hasMultipleIds) {
-    renderValue = [renderValue, expansionLink];
   }
 
 

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -3,23 +3,32 @@ const classNames = require('classnames');
 const _ = require('lodash');
 const config = require('./config');
 
+//Define entry limit for trim mode
+const defaultEntryLimit = 3;
+const commentEntryLimit = 1;
 
 //Handle name related metadata fields
 const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Name: ');
 const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
 
-const nameHandlerTrim = (pair) => {
-  let shortArray = filterChemicalFormulas(trimValue(pair[1], 3));
+const nameHandlerTrim = (pair, expansionFunction) => {
+  let revisedList = filterChemicalFormulas(pair[1]);
+  let shortArray = trimValue(revisedList, defaultEntryLimit);
+  let expansionLink = revisedList.length > defaultEntryLimit ?
+    h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »') : h('div.error');
+
   return h('div.fake-paragraph', [
     h('div.field-name', 'Synonyms:'),
-    valueToHtml(shortArray, true)
+    valueToHtml(shortArray, true),
+    expansionLink
   ]);
 };
-const nameHandler = (pair) => {
+const nameHandler = (pair, expansionFunction) => {
   let shortArray = filterChemicalFormulas(pair[1]);
   return h('div.fake-paragraph', [
     h('div.field-name', 'Synonyms:'),
-    valueToHtml(shortArray, true)
+    valueToHtml(shortArray, true),
+    h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, '« less')
   ]);
 };
 
@@ -31,14 +40,15 @@ const dataSourceHandler = (pair) => {
   return h('div.fake-paragraph', link);
 };*/
 
-const databaseHandlerTrim = (pair) => {
+const databaseHandlerTrim = (pair, expansionFunction) => {
+  const expansionLink = h('div.more-link', { onClick: () => expansionFunction(pair[0]) }, 'more »');
   if (pair[1].length < 1) { return h('div.error'); }
-  return generateDatabaseList(sortByDatabaseId(pair[1]), true);
+  return generateDatabaseList(sortByDatabaseId(pair[1]), true, expansionLink);
 };
-const databaseHandler = (pair) => {
-  //Sort the array by database names
+const databaseHandler = (pair, expansionFunction) => {
+  const expansionLink = h('div.more-link', { onClick: () => expansionFunction(pair[0]) }, '« less');
   if (pair[1].length < 1) { return h('div.error'); }
-  return generateDatabaseList(sortByDatabaseId(pair[1]), false);
+  return generateDatabaseList(sortByDatabaseId(pair[1]), false, expansionLink);
 
 };
 
@@ -56,14 +66,33 @@ const typeHandler = (pair) => {
 };
 
 //Handle comment related fields
-const commentHandler = (pair) => {
+const commentHandler = (pair, expansionFunction) => {
   //Filter out replaced entries
   let comments = removedReplacedComments(pair[1]);
 
   //Don't print comments if there are none.
-  if(comments.length < 1) { return h('div.error');}
+  if (comments.length < 1) { return h('div.error'); }
 
-  return h('div.fake-paragraph', [ h('div.field-name', 'Comments' + ': '), valueToHtml(comments, false)]);
+  //Generate expansion link
+  let expansionLink = h('div.more-link', { onClick: () => expansionFunction(pair[0]) }, '« less');
+  comments[comments.length - 1] = [comments[comments.length - 1], expansionLink];
+
+  return h('div.fake-paragraph', [h('div.field-name', 'Comments' + ': '), valueToHtml(comments, false)]);
+};
+const commentHandlerTrim = (pair, expansionFunction) => {
+  //Filter out replaced entries
+  let comments = removedReplacedComments(pair[1]);
+  let shortArray = trimValue(comments, commentEntryLimit);
+  //Don't print comments if there are none.
+
+  if (comments.length < 1) { return h('div.error'); }
+
+  //Generate expansion link
+  let expansionLink = comments.length > commentEntryLimit ?
+    h('div.more-link', { onClick: () => { console.log(expansionFunction, pair); expansionFunction(pair[0]);} }, 'more »') : null;
+  if (expansionLink) { shortArray[commentEntryLimit - 1] = [shortArray[commentEntryLimit - 1], expansionLink]; }
+
+  return h('div.fake-paragraph', [h('div.field-name', 'Comments' + ': '), valueToHtml(shortArray, false)]);
 };
 
 //Default to generating a list of all items
@@ -88,12 +117,13 @@ const metaDataKeyMap = new Map()
   .set('Database IDsTrim', databaseHandlerTrim)
   .set('Publications', publicationHandler)
   .set('PublicationsTrim', publicationHandler)
-  .set('Comment', commentHandler);
+  .set('Comment', commentHandler)
+  .set('CommentTrim', commentHandlerTrim);
 
 //Generate HTML elements for a Parsed Metadata Field
 //Optional trim parameter indicates if the data presented should be trimmed to a reasonable length
 //Data Pair -> HTML
-function parseMetadata(pair, trim = true) {
+function parseMetadata(pair, trim = true, expansionFunction) {
   const doNotRender = ['Data Source', 'Data SourceTrim', 'Display Name'];
   let key = pair[0];
 
@@ -104,7 +134,7 @@ function parseMetadata(pair, trim = true) {
 
   let handler = metaDataKeyMap.get(key);
   if (handler) {
-    return handler(pair);
+    return handler(pair, expansionFunction);
   }
   else if (!(trim) && !doNotRender.includes(key)) {
     return defaultHandler(pair);
@@ -128,6 +158,7 @@ function trimValue(value, n) {
 //Create a HTML Element for a given value
 //Note : Optional isCommaSeparated parameter indicates if the list should be
 //       printed as a comma separated list.
+//       Optional expansion link parameter defines a expansion link property
 //Requires a populated array
 //Anything -> HTML
 function valueToHtml(value, isCommaSeparated = false) {
@@ -296,7 +327,7 @@ function noDataWarning(name) {
 function filterChemicalFormulas(list) {
   //Filter out Chemical formulas
   if (list instanceof Array) { return list.filter(name => (!name.trim().match(/^([^J][0-9BCOHNSOPrIFla@+\-\[\]\(\)\\=#$]{6,})$/ig))); }
-  return list;
+  return [list];
 }
 
 //Create a publication list
@@ -325,7 +356,7 @@ function publicationList(data) {
       h('a.publication-link', { href: url, target: '_blank' }, title),
       h('div.publication-subinfo', [
         h('div.publication-inline', authors),
-        h('div', {className : classNames('publication-divider', 'publication-inline')}, '|'),
+        h('div', { className: classNames('publication-divider', 'publication-inline') }, '|'),
         h('div.publication-inline', publicationInfo)
       ])
     ]);
@@ -338,10 +369,13 @@ function publicationList(data) {
 
 //Generate a list of database ids from sorted array
 //Array -> HTML
-function generateDatabaseList(sortedArray, trim) {
+function generateDatabaseList(sortedArray, trim, expansionLink) {
 
   //Ignore Publication references
   sortedArray = sortedArray.filter(databaseEntry => databaseEntry.database.toUpperCase() !== 'PUBMED');
+
+  //Determine if there is more than one link for a database
+  var hasMultipleIds = _.find(sortedArray, databaseRef => databaseRef.ids.length > 1);
 
   //Generate list
   let renderValue = sortedArray.map(item => generateIdList(item, trim), this);
@@ -351,18 +385,24 @@ function generateDatabaseList(sortedArray, trim) {
     renderValue = h('div.wrap-text', h('ul.db-list', renderValue));
   }
 
+  //Append expansion link to render value if one exists
+  if (expansionLink && hasMultipleIds) {
+    renderValue = [renderValue, expansionLink];
+  }
+
+
   return h('div.fake-paragraph', [h('div.span-field-name', 'Links :'), renderValue]);
 }
 
 //Replace any instances of Replaced 
 //Anything -> Array 
-function removedReplacedComments(comments){
+function removedReplacedComments(comments) {
   const replacedExists = comment => comment.toUpperCase().includes('REPLACED');
 
-  if(typeof comments === 'string'){
+  if (typeof comments === 'string') {
     return replacedExists(comments) ? [] : comments;
   }
-  else if (!(comments)){
+  else if (!(comments)) {
     return [];
   }
   else {

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -3,8 +3,6 @@ const classNames = require('classnames');
 const _ = require('lodash');
 const config = require('./config');
 
-
-
 //Handle name related metadata fields
 const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Name: ');
 const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
@@ -79,7 +77,7 @@ const commentHandler = (pair, expansionFunction) => {
 const commentHandlerTrim = (pair, expansionFunction) => {
   //Filter out replaced entries
   let comments = removedReplacedComments(pair[1]);
-  let shortArray = trimValue(comments, config.config.commentEntryLimut);
+  let shortArray = trimValue(comments, config.config.commentEntryLimit);
   //Don't print comments if there are none.
 
   if (comments.length < 1) { return h('div.error'); }

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -318,11 +318,13 @@ function noDataWarning(name) {
 }
 
 //Filter out chemical formulas
-//Array -> Array
-function filterChemicalFormulas(list) {
+//Anything -> Array
+function filterChemicalFormulas(names) {
   //Filter out Chemical formulas
-  if (list instanceof Array) { return list.filter(name => (!name.trim().match(/^([^J][0-9BCOHNSOPrIFla@+\-\[\]\(\)\\=#$]{6,})$/ig))); }
-  return [list];
+  if (names instanceof Array) { return names.filter(name => (!name.trim().match(/^([^J][0-9BCOHNSOPrIFla@+\-\[\]\(\)\\=#$]{6,})$/ig))); }
+
+  //Produce an array to avoid generation functions from throwing errors. 
+  return [names];
 }
 
 //Create a publication list

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -62,7 +62,7 @@ const publicationHandler = (pair) => {
 const typeHandler = (pair) => {
   let type = pair[1].toString().substring(3);
   let formattedType = type.replace(/([A-Z])/g, ' $1').trim();
-  return h('div.fake-paragraph', [h('div.field-name', pair[0] + ': '), h('div.tooltip-value', formattedType)]);
+  return h('div.tooltip-type',  formattedType);
 };
 
 //Handle comment related fields

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -8,8 +8,8 @@ const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Name: ');
 const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
 const nameHandlerTrim = (pair, expansionFunction) => {
   let revisedList = filterChemicalFormulas(pair[1]);
-  let shortArray = trimValue(revisedList, config.defaultEntry);
-  let expansionLink = revisedList.length > config.defaultEntry ?
+  let shortArray = trimValue(revisedList, config.defaultEntryLimit);
+  let expansionLink = revisedList.length > config.defaultEntryLimit ?
     h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »') : h('div.error');
 
   return h('div.fake-paragraph', [
@@ -77,15 +77,15 @@ const commentHandler = (pair, expansionFunction) => {
 const commentHandlerTrim = (pair, expansionFunction) => {
   //Filter out replaced entries
   let comments = removedReplacedComments(pair[1]);
-  let shortArray = trimValue(comments, config.config.commentEntryLimit);
+  let shortArray = trimValue(comments, config.commentEntryLimit);
   //Don't print comments if there are none.
 
   if (comments.length < 1) { return h('div.error'); }
 
   //Generate expansion link
-  let expansionLink = comments.length > config.commentEntryLimut ?
+  let expansionLink = comments.length > config.commentEntryLimit ?
     h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »') : null;
-  if (expansionLink) { shortArray[config.commentEntryLimut - 1] = [shortArray[config.commentEntryLimut - 1], expansionLink]; }
+  if (expansionLink) { shortArray[config.commentEntryLimit - 1] = [shortArray[config.commentEntryLimit - 1], expansionLink]; }
 
   return h('div.fake-paragraph', [h('div.field-name', 'Comments' + ': '), valueToHtml(shortArray, false)]);
 };

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -3,18 +3,15 @@ const classNames = require('classnames');
 const _ = require('lodash');
 const config = require('./config');
 
-//Define entry limit for trim mode
-const defaultEntryLimit = 3;
-const commentEntryLimit = 1;
+
 
 //Handle name related metadata fields
 const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Name: ');
 const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
-
 const nameHandlerTrim = (pair, expansionFunction) => {
   let revisedList = filterChemicalFormulas(pair[1]);
-  let shortArray = trimValue(revisedList, defaultEntryLimit);
-  let expansionLink = revisedList.length > defaultEntryLimit ?
+  let shortArray = trimValue(revisedList, config.defaultEntry);
+  let expansionLink = revisedList.length > config.defaultEntry ?
     h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »') : h('div.error');
 
   return h('div.fake-paragraph', [
@@ -82,15 +79,15 @@ const commentHandler = (pair, expansionFunction) => {
 const commentHandlerTrim = (pair, expansionFunction) => {
   //Filter out replaced entries
   let comments = removedReplacedComments(pair[1]);
-  let shortArray = trimValue(comments, commentEntryLimit);
+  let shortArray = trimValue(comments, config.config.commentEntryLimut);
   //Don't print comments if there are none.
 
   if (comments.length < 1) { return h('div.error'); }
 
   //Generate expansion link
-  let expansionLink = comments.length > commentEntryLimit ?
+  let expansionLink = comments.length > config.commentEntryLimut ?
     h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »') : null;
-  if (expansionLink) { shortArray[commentEntryLimit - 1] = [shortArray[commentEntryLimit - 1], expansionLink]; }
+  if (expansionLink) { shortArray[config.commentEntryLimut - 1] = [shortArray[config.commentEntryLimut - 1], expansionLink]; }
 
   return h('div.fake-paragraph', [h('div.field-name', 'Comments' + ': '), valueToHtml(shortArray, false)]);
 };

--- a/src/client/common/tooltips/metadataTip.js
+++ b/src/client/common/tooltips/metadataTip.js
@@ -80,7 +80,7 @@ class MetadataTip {
     this.validateName();
 
     //Generate the expand field option
-    const expandFunction = this.displayMore(); 
+    const expandFunction = this.displayMore();
 
     if (!(this.data)) { this.data = []; }
     return h('div.tooltip-image', [
@@ -157,7 +157,7 @@ class MetadataTip {
     //Hide existing tooltip 
     const existingToolTip = expansionObject.tooltipExt;
     existingToolTip.hide(existingToolTip.store[0].popper);
-    
+  
     //Get tooltip objects
     let tooltip = expansionObject.tooltip;
     const expandedHTML = expansionObject.generateExtendedToolTip();

--- a/src/client/common/tooltips/metadataTip.js
+++ b/src/client/common/tooltips/metadataTip.js
@@ -171,7 +171,9 @@ class MetadataTip {
       hideOnClick: false,
       arrow: true,
       position: 'bottom',
-      animation : 'fade'});
+      animation: 'shift',
+      duration : 1
+    });
 
 
     //Resolve Reference issues

--- a/src/client/common/tooltips/metadataTip.js
+++ b/src/client/common/tooltips/metadataTip.js
@@ -16,6 +16,7 @@ class MetadataTip {
     this.data = data.parsedMetadata;
     this.cyElement = cyElement;
     this.db = config.databases;
+    this.viewStatus = {};
   }
 
   //Show Tippy Tooltip
@@ -24,7 +25,7 @@ class MetadataTip {
     let tooltip = this.tooltip;
     let tooltipExt = tooltip;
 
-    getPublications(this.data).then(function(data) {
+    getPublications(this.data).then(function (data) {
       this.data = data;
 
       //Hide all other tooltips
@@ -38,9 +39,9 @@ class MetadataTip {
 
         //Create tippy object
         let refObject = this.cyElement.popperRef();
-        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true, position: 'bottom' });
-        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true, position: 'bottom'});
-               //Resolve Reference issues
+        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom' });
+        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom' });
+        //Resolve Reference issues
         tooltip.selector.dim = refObject.dim;
         tooltip.selector.cyElement = refObject.cyElement;
         tooltipExt.selector.dim = refObject.dim;
@@ -78,20 +79,13 @@ class MetadataTip {
     //Ensure name is not blank
     this.validateName();
 
+    //Generate the expand field option
+    const expandFunction = this.displayMore(); 
+
     if (!(this.data)) { this.data = []; }
     return h('div.tooltip-image', [
       h('div.tooltip-heading', this.name),
-      h('div.tooltip-internal', h('div', (data).map(item => generate.parseMetadata(item, true)), this)),
-      h('div.tooltip-buttons',
-        [
-          h('div.tooltip-button-container',
-            [
-              h('div.tooltip-button', { onclick: this.displayMore() }, [
-                h('i', { className: classNames('material-icons', 'tooltip-button-show') }, 'fullscreen'),
-                h('div.describe-button', 'Additional Info')
-              ]),
-            ])
-        ])
+      h('div.tooltip-internal', h('div', (data).map(item => generate.parseMetadata(item, true, expandFunction)), this))
     ]);
   }
 
@@ -109,20 +103,16 @@ class MetadataTip {
     //Ensure name is not blank
     this.validateName();
 
+    //Generate expansion and collapse functions 
+    const expandFunction = this.displayMore();
+    const collapseFunction = this.displayLess();
+
+    const getExpansionFunction = item => !this.isExpanded(item[0]) ? expandFunction : collapseFunction;
+
     if (!(this.data)) { this.data = []; }
     return h('div.tooltip-image', [
       h('div.tooltip-heading', this.name),
-      h('div.tooltip-internal', h('div', (data).map(item => generate.parseMetadata(item, false), this))),
-      h('div.tooltip-buttons',
-        [
-          h('div.tooltip-button-container',
-            [
-              h('div.tooltip-button', { onclick: this.displayLess() }, [
-                h('i', { className: classNames('material-icons', 'tooltip-button-show') }, 'fullscreen_exit'),
-                h('div.describe-button', 'Less Info')
-              ]),
-            ])
-        ])
+      h('div.tooltip-internal', h('div', (data).map(item => generate.parseMetadata(item, !this.isExpanded(item[0]), getExpansionFunction(item)), this)))
     ]
     );
   }
@@ -143,12 +133,13 @@ class MetadataTip {
       this.tooltipExt.hide(this.tooltipExt.store[0].popper);
     }
     this.visible = false;
+    this.viewStatus = {};
   }
 
   //Destroy Tippy tooltip
   destroy() {
     if (this.tooltip) {
-      this.tooltip.destory(this.tooltip.store[0].popper);
+      this.tooltip.destroy(this.tooltip.store[0].popper);
       this.tooltip = null;
     }
   }
@@ -159,28 +150,57 @@ class MetadataTip {
   }
 
   //Display the expanded tooltip
-  expandToolTip(tooltip, tooltipExt) {
+  expandToolTip(expansionObject, expansionField, fieldStatus) {
+    //Modify view status
+    expansionObject.viewStatus[expansionField] = fieldStatus;
+
+    //Hide existing tooltip 
+    const existingToolTip = expansionObject.tooltipExt;
+    existingToolTip.hide(existingToolTip.store[0].popper);
+    
+    //Get tooltip objects
+    let tooltip = expansionObject.tooltip;
+    const expandedHTML = expansionObject.generateExtendedToolTip();
+
+    //Create tippy object
+    let refObject = expansionObject.cyElement.popperRef();
+    let tooltipExt = tippy(refObject, { html: expandedHTML,
+      theme: 'light',
+      interactive: true,
+      trigger: 'manual',
+      hideOnClick: false,
+      arrow: true,
+      position: 'bottom',
+      animation : 'fade'});
+
+
+    //Resolve Reference issues
+    tooltipExt.selector.dim = refObject.dim;
+    tooltipExt.selector.cyElement = refObject.cyElement;
+
+    //Hide and show
     tooltip.hide(tooltip.store[0].popper);
     tooltipExt.show(tooltipExt.store[0].popper);
-  }
 
-
-  //Display the expanded tooltip
-  collapseToolTip(tooltip, tooltipExt) {
-    tooltip.show(tooltip.store[0].popper);
-    tooltipExt.hide(tooltipExt.store[0].popper);
+    //Save extended tooltip
+    expansionObject.tooltipExt = tooltipExt;
   }
 
   //Return a function that binds a tooltip to the expanded tooltip view
   displayMore() {
     let that = this;
-    return () => that.expandToolTip(that.tooltip, that.tooltipExt);
+    return (field) => that.expandToolTip(that, field, true);
   }
 
   //Return a function that binds an expanded tooltip to the minimized view.
   displayLess() {
     let that = this;
-    return () => that.collapseToolTip(that.tooltip, that.tooltipExt);
+    return (field) => that.expandToolTip(that, field, false);
+  }
+
+  //Return the expansion status of a specified field
+  isExpanded(field) {
+    return this.viewStatus[field];
   }
 
 }

--- a/src/client/common/tooltips/metadataTip.js
+++ b/src/client/common/tooltips/metadataTip.js
@@ -38,8 +38,8 @@ class MetadataTip {
 
         //Create tippy object
         let refObject = this.cyElement.popperRef();
-        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true });
-        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true  });
+        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true, position: 'bottom' });
+        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow : true, position: 'bottom'});
                //Resolve Reference issues
         tooltip.selector.dim = refObject.dim;
         tooltip.selector.cyElement = refObject.cyElement;

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -234,6 +234,7 @@
   text-decoration: underline;
   font-style: italic;
   cursor: pointer;
+  white-space: pre;
 }
 
 

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -92,6 +92,21 @@
   word-wrap: break-word;
 }
 
+.tooltip-type{
+  display: inline;
+  word-wrap: break-word;
+  line-height: 2em;
+  background-color: rgba(22, 160, 133, 0.5);
+  color: black;
+	list-style:none;
+	margin: 0 5px;
+	padding: 0 15px;
+	-moz-border-radius: 5px;
+	-webkit-border-radius: 5px;
+	-moz-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
+	-webkit-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
+}
+
 .tooltip-comma-item {
   padding: 2px;
   display: inline;
@@ -215,7 +230,7 @@
   color: var(--link);
   margin: 4px;
   font-weight: lighter;
-  display: inline-block;
+  display: inline;
   text-decoration: underline;
   font-style: italic;
   cursor: pointer;

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -211,6 +211,16 @@
   width: 100%;
 }
 
+.more-link {
+  color: var(--link);
+  margin: 4px;
+  font-weight: lighter;
+  display: inline-block;
+  text-decoration: underline;
+  font-style: italic;
+  cursor: pointer;
+}
+
 
 /* Tippy JS Style Overrides */
 


### PR DESCRIPTION
.This PR implements all the suggested tooltip UI changes made during the Tuesday meeting with Gary. 

### Tooltip Style Changes
closes #226 
- Removed type field from tooltip, but kept the type name
- Changed `approved name` to `name`
- Changed Database References` to Links
- Changed default position to `bottom`
- Assigned a max height to tooltip

### Tooltip Expansion Changes
closes #261

The tooltip expand button has been removed. Comments, Links, and Synonyms now have their options to individual expand and close data.

### Screenshots
####  Regular tooltip
![screen shot 2017-11-29 at 1 26 34 pm](https://user-images.githubusercontent.com/1313810/33392951-8fe218e2-d50b-11e7-9b96-12daa9818a56.png)

#### Scrollable tooltip with max height 
![screen shot 2017-11-29 at 1 20 46 pm](https://user-images.githubusercontent.com/1313810/33392978-9f75c66e-d50b-11e7-96bc-93256a9efb63.png)

#### Expandable Synonymns
![expand ex](https://user-images.githubusercontent.com/1313810/33392991-aab24318-d50b-11e7-8f7e-f376b36a28c5.gif)

#### Expandable Comments
![expand com](https://user-images.githubusercontent.com/1313810/33393002-b22f8d4e-d50b-11e7-82bf-eaac90cdda55.gif)
