### PR TITLE
Disabled extra layouts in view mode

### DIFF
--- a/src/client/common/cy/layout/index.js
+++ b/src/client/common/cy/layout/index.js
@@ -1,7 +1,7 @@
 const layouts = [
   {
     displayName: 'Force Directed',
-    description: 'Layout algorithm for undirected compound graphs',
+    description: 'For undirected compound graphs',
     options: {
       name: 'cose-bilkent',
       nodeDimensionsIncludeLabels: true,
@@ -13,7 +13,7 @@ const layouts = [
   },
   {
     displayName: 'Tree',
-    description: 'For DAGs and trees',
+    description: 'For DAGs',
     options: {
       name: 'dagre',
       rankDir: 'LR',
@@ -23,7 +23,7 @@ const layouts = [
   },
   {
     displayName: 'Layered',
-    description: 'Layer-based layout for node-link diagrams',
+    description: 'For node-link diagrams',
     options: {
       name: 'klay',
       animate: true,

--- a/src/client/features/view/components/menu/index.js
+++ b/src/client/features/view/components/menu/index.js
@@ -56,7 +56,6 @@ class Menu extends React.Component {
     const cy = props.cy;
 
     const layoutOpts = _.find(props.availableLayouts, (layout) => layout.displayName === selectedLayoutName).options;
-
     let layout = cy.layout(layoutOpts);
     layout.pon('layoutstop').then(function () {
       if (props.admin && selectedLayoutName !== humanLayoutDisplayName) {
@@ -169,9 +168,9 @@ class Menu extends React.Component {
             }, [h('i.material-icons', this.state.complexesExpanded ? 'select_all' : 'settings_overscan')]),
             h('div', {
               className: classNames('tool-button', { 'tool-button-active': this.state.dropdownOpen }),
-              onClick: () => this.setState({ dropdownOpen: !this.state.dropdownOpen }),
-              title: 'Rearrange entities'
-            }, [h('i.material-icons', 'shuffle')]),
+              onClick: () => this.props.admin ? this.setState({ dropdownOpen: !this.state.dropdownOpen }) : this.performLayout(this.state.selectedLayout),
+              title: this.props.admin ? 'Reset arrangement' : 'Arrange display'
+            }, [h('i.material-icons', this.props.admin ? 'shuffle' : 'replay')]),
             h('div', {
               className: classNames('layout-dropdown', { 'layout-dropdown-open': this.state.dropdownOpen })
             }, [

--- a/src/client/features/view/index.js
+++ b/src/client/features/view/index.js
@@ -50,6 +50,7 @@ class View extends React.Component {
       });
     });
   }
+
   componentWillMount() {
     if (this.props.admin) {
       bindMove(this.state.query.uri, 'latest', this.state.cy);


### PR DESCRIPTION
Addresses issues in #263, namely

- Change ‘Rearrange Entities’ to ‘Arrange Display’
- Update display descriptions to be more descriptive
- Make layouts option available in edit mode only
- Add a reset button to the menu bar with the default being human created layouts, and if there is none, CoSE-Bilkent

![screen shot 2017-11-29 at 2 33 48 pm](https://user-images.githubusercontent.com/15696989/33395062-5bdc8a3a-d512-11e7-9eb8-bcbbae94328a.png)