### PR TITLE
Escaping backslashes; blacklisting gene name recognition

### DIFF
--- a/src/server/pathway-commons/search/hgnc.js
+++ b/src/server/pathway-commons/search/hgnc.js
@@ -12,7 +12,7 @@ const parseHGNCData = text => {
 
   let parsed = textNoHeader.split(/[\s,]+/)
     .filter(symbol => {
-      return symbol.length > 0 || symbolNameBlackList.indexOf(symbol) == -1;
+      return symbol.length > 0 && symbolNameBlackList.indexOf(symbol) == -1;
     });
 
   return parsed;

--- a/src/server/pathway-commons/search/index.js
+++ b/src/server/pathway-commons/search/index.js
@@ -5,7 +5,7 @@ const getHGNCData = require('./hgnc');
 const sanitize = (s) => {
   // Escape (with '\'), to treat them literally, symbols, such as '*', ':', or space, 
   // which otherwise play special roles in a Lucene query string.
-  return s.replace(/([\!\*\+\-\&\|\(\)\[\]\{\}\^\~\?\:\/\\"\s])/g, '\\$1')
+  return s.replace(/([\!\*\+\-\&\|\(\)\[\]\{\}\^\~\?\:\/\\"\s])/g, '\\\\$1')
 };
 
 const processPhrase = (phrase, collection) => {
@@ -16,15 +16,21 @@ const processPhrase = (phrase, collection) => {
     'refseq'
   ];
 
+  // Do NOT recognize these gene symbols
+  const symbolNameBlackList = [
+    'CELL'
+  ];  
+
   const tokens = phrase.split(/\s+/g);
 
   return tokens
     .map(token => {
       //if symbol is recognized by at least one source
+      const blackListed = symbolNameBlackList.indexOf(token.toUpperCase()) > -1;
       const recognized = sourceList.some(source => utilities.sourceCheck(source, token))
                               || collection.has(token.toUpperCase());
       const sanitized = sanitize(token);
-      return recognized ? ( 'xrefid:' + sanitized ) : ( 'name:' + '*' + sanitized + '*' );
+      return !blackListed && recognized ? ( 'xrefid:' + sanitized ) : ( 'name:' + '*' + sanitized + '*' );
     });
 };
 

--- a/src/server/pathway-commons/search/index.js
+++ b/src/server/pathway-commons/search/index.js
@@ -15,22 +15,16 @@ const processPhrase = (phrase, collection) => {
     'smpdb',
     'refseq'
   ];
-
-  // Do NOT recognize these gene symbols
-  const symbolNameBlackList = [
-    'CELL'
-  ];  
-
   const tokens = phrase.split(/\s+/g);
 
   return tokens
     .map(token => {
       //if symbol is recognized by at least one source
-      const blackListed = symbolNameBlackList.indexOf(token.toUpperCase()) > -1;
+      // const blackListed = symbolNameBlackList.indexOf(token.toUpperCase()) > -1;
       const recognized = sourceList.some(source => utilities.sourceCheck(source, token))
                               || collection.has(token.toUpperCase());
       const sanitized = sanitize(token);
-      return !blackListed && recognized ? ( 'xrefid:' + sanitized ) : ( 'name:' + '*' + sanitized + '*' );
+      return recognized ? ( 'xrefid:' + sanitized ) : ( 'name:' + '*' + sanitized + '*' );
     });
 };
 


### PR DESCRIPTION
1. The backslashes have to be escaped due to 'pathway-commons' npm package escape of backslashes.
2. The 'blacklist' was present in pathways-search but removed, but I put it back because hgnSymbols contains stupid gene symbols alternative names (e.g. 'cell')
