### PR TITLE
Small browser compatibility fixes

### DIFF
--- a/src/styles/features/view/menuBar.css
+++ b/src/styles/features/view/menuBar.css
@@ -76,7 +76,7 @@
 
   height: calc(var(--icon-size) * 3 / 2);
   //width: calc((var(--icon-size) * 3 / 2) * var(--number-of-sidebar-icons));
-
+ 
   position: absolute;
   top: 100%;
   left: -1px;
@@ -87,6 +87,12 @@
   border-width: 1px 1px 1px 1px;
 
   background-color: rgba(255, 255, 255, 0.5);
+}
+
+_::-webkit-full-page-media, _:future, :root .view-toolbar{
+
+   min-width: 100%;
+
 }
 
 .tool-button {

--- a/src/styles/features/view/menuBar.css
+++ b/src/styles/features/view/menuBar.css
@@ -95,36 +95,6 @@ _::-webkit-full-page-media, _:future, :root .view-toolbar{
 
 }
 
-.tool-button {
-  @extend %flex-center;
-  @extend %no-select;
-
-  height: calc(var(--icon-size) * 3 / 2.2);
-  width: calc(var(--icon-size) * 3 / 2.2);
-  margin-left: 0.12em;
-  margin-right: 0.12em;
-
-  position: relative;
-
-  //border: 1px solid var(--light-base-colour-dark);
-  border-radius: 50%;
-  transition: all 0.1s linear;
-
-  
-  font-size: var(--icon-size);
-  color: var(--dark-base-colour);
-
-  cursor: pointer;
-
-  &:hover {
-    background-color: var(--light-base-colour-dark);
-  }
-
-  &.tool-button-active {
-    color: var(--accent-1-colour);
-  }
-}
-
 .layout-dropdown {
   @extend %flex-center;
 
@@ -189,7 +159,7 @@ _::-webkit-full-page-media, _:future, :root .view-toolbar{
 
 .view-search {
   height: 100% !important;
-  width: 100%;
+  width: 90%;
 
   padding: 0 0 1px 0 !important;
 


### PR DESCRIPTION
Fixed an issue with padding in Firefox, and added a nasty patch job to make the menu bar behave a little better in Safari. It would seem Safari doesn't bother calculating the width of inner components of absolutely positioned divs, meaning the toolbar ends up looking like this in Safari:

![screen shot 2017-12-11 at 9 28 08 am](https://user-images.githubusercontent.com/15696989/33835803-a20ef7c6-de55-11e7-81e5-5a9a5a5cfcf4.png)

The fix I made here doesn't fix that, but makes the animations work smoothly, whereas they used to be jerky.

Any ideas about how to fix the wide toolbar in Safari?
