### PR TITLE
DEMO : Re added display name back to the tooltip

### DIFF
--- a/src/client/common/config.js
+++ b/src/client/common/config.js
@@ -24,7 +24,7 @@ const databases = [
 ];
 
 const publicationsURL = 'http://identifiers.org/pubmed/';
-const tooltipOrder = ['Type', 'Display Name', 'Standard Name', 'Names', 'Database IDs', 'Publications'];
+const tooltipOrder = ['Type', 'Standard Name', 'Display Name', 'Names', 'Database IDs', 'Publications'];
 const tooltipReverseOrder = ['Comment'];
 
 const defaultEntryLimit = 3;

--- a/src/client/common/tooltips/generateContent.js
+++ b/src/client/common/tooltips/generateContent.js
@@ -6,6 +6,7 @@ const config = require('../config');
 //Handle name related metadata fields
 const standardNameHandler = (pair) => makeTooltipItem(pair[1], 'Name: ');
 const standardNameHandlerTrim = (pair) => standardNameHandler(pair);
+const displayNameHandler = (pair) => makeTooltipItem(pair[1], 'Display Name: ');
 const nameHandlerTrim = (pair, expansionFunction) => {
   let revisedList = filterChemicalFormulas(pair[1]);
   let shortArray = trimValue(revisedList, config.defaultEntryLimit);
@@ -104,6 +105,8 @@ const defaultHandler = (pair) => {
 const metaDataKeyMap = new Map()
   .set('Standard Name', standardNameHandler)
   .set('Standard NameTrim', standardNameHandlerTrim)
+  .set('Display Name', displayNameHandler)
+  .set('Display NameTrim', displayNameHandler)
   .set('Type', typeHandler)
   .set('TypeTrim', typeHandler)
   .set('Names', nameHandler)


### PR DESCRIPTION
I re added the display name field to the tooltip as it contained information that was important for certain nodes.  @jvwong  highlighted such a case here #327 