### PR TITLE
Context Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cytoscape": "git+https://github.com/cytoscape/cytoscape.js.git#unstable",
     "cytoscape-cola": "^2.0.0",
     "cytoscape-compound-collapse": "git+https://github.com/d2fong/cytoscape.js-compound-collapse.git",
+    "cytoscape-context-menus": "^3.0.5",
     "cytoscape-cose-bilkent": "^3.0.2",
     "cytoscape-cxtmenu": "^2.10.3",
     "cytoscape-dagre": "^2.0.0",

--- a/src/client/common/cy/events/click.js
+++ b/src/client/common/cy/events/click.js
@@ -12,7 +12,7 @@ const hideTooltips = (cy) => {
 //Requires a valid cytoscape element
 //Note : Optional reset parameter set the counter to 0
 const incrementClicks = (cy, reset) => {
-  if (reset){
+  if (reset) {
     cy.scratch('_clicks', 0);
     return 0;
   }
@@ -77,6 +77,11 @@ const bindClick = (cy) => {
   cy.on('drag', evt => hideTooltips(evt.cy));
   cy.on('pan', evt => hideTooltips(evt.cy));
   cy.on('zoom', evt => hideTooltips(evt.cy));
+
+  //Custom hide all tooltip event
+  cy.on('hideTooltips', evt => hideTooltips(evt.cy));
+
+  
 };
 
 module.exports = bindClick;

--- a/src/client/cytoscape-extensions.js
+++ b/src/client/cytoscape-extensions.js
@@ -12,6 +12,7 @@ const fisheye = require('cytoscape-fisheye');
 
 //Tooltips
 const popper = require('cytoscape-popper');
+const cxtmenu = require('cytoscape-cxtmenu');
 
 module.exports = () => {
   cytoscape.use(cola);
@@ -21,5 +22,6 @@ module.exports = () => {
   cytoscape.use(compoundCollapse);
   cytoscape.use(fisheye);
   cytoscape.use(popper);
+  cytoscape.use(cxtmenu);
   // cytoscape.use(tippy);
 };

--- a/src/client/features/view/components/graph/contextMenu.js
+++ b/src/client/features/view/components/graph/contextMenu.js
@@ -1,0 +1,52 @@
+const _ = require('lodash');
+
+const defaults = {
+  menuRadius: 80,
+  fillColor: 'rgba(0, 0, 0, 0.75)',
+  activeFillColor: 'rgba(1, 105, 217, 0.75)',
+  activePadding: 10,
+  indicatorSize: 12,
+  separatorWidth: 3,
+  minSpotlightRadius: 12,
+  maxSpotlightRadius: 12,
+  openMenuEvents: 'cxttapstart taphold',
+  itemColor: 'white',
+  itemTextShadowColor: 'transparent',
+  zIndex: 9999,
+  atMouse: false
+};
+
+const expandCollapse = generateCommand('settings_overscan', 'Expand/Collapse', ele => {
+  ele.emit('hideTooltips');
+  ele.emit('expandCollapse');
+});
+const getInfo = generateCommand('info_outline', 'More Info', ele =>  ele.emit('showTooltip'));
+
+//Create a cxt menu command object
+function generateCommand(icon, title, selectFunction) {
+  return {
+    content: '<i class="material-icons cxt-icon">' + icon + '</i> <div class="cxt-info">' + title + '</div>',
+    select: selectFunction
+  };
+}
+
+//Build a ctx options object
+function getCtxOptions(commands, selector) {
+  return _.assign({}, defaults, {
+    selector: selector,
+    commands: commands
+  });
+}
+//Create a context menu instance and bind it to cy
+function bindContextMenu(cy) {
+
+  //Get options
+  const complexNodeMenu = getCtxOptions([expandCollapse, getInfo], 'node[class="complex"]');
+  const regularNodeMenu = getCtxOptions([getInfo], 'node[class!="complex"]');
+
+  //Create context menus
+  cy.cxtmenu(complexNodeMenu);
+  cy.cxtmenu(regularNodeMenu);
+}
+
+module.exports = bindContextMenu;

--- a/src/client/features/view/components/graph/index.js
+++ b/src/client/features/view/components/graph/index.js
@@ -1,7 +1,8 @@
 const React = require('react');
 const h = require('react-hyperscript');
-
 const _ = require('lodash');
+
+const bindContextMenu = require('./contextMenu');
 
 /* Props
 - updateRenderStatus(status)
@@ -28,6 +29,7 @@ class Graph extends React.Component {
     const container = this.graphDOM;
     this.props.cy.mount(container);
     this.checkRenderGraph(this.props.graphJSON);
+    bindContextMenu(this.props.cy);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/styles/features/view.css
+++ b/src/styles/features/view.css
@@ -2,6 +2,7 @@
 @import "./view/graph.css";
 @import "./view/sidebarMenu.css";
 @import "./view/toolTip.css";
+@import "./view/contextMenu.css";
 
 .View {
   width: 100vw;

--- a/src/styles/features/view/contextMenu.css
+++ b/src/styles/features/view/contextMenu.css
@@ -1,0 +1,11 @@
+/* Insert Styling for Context Menu Here */
+/* This Should be used when Context Menus are added */ 
+
+.cxt-info {
+  font-size: 0.45em;
+  padding: 2px;
+}
+
+.cxt-icon {
+  font-size: 1.4em;
+}


### PR DESCRIPTION
#321 

Jeff suggested adding a context menu to allow for additional options beyond expand/collapse and show tooltip.

I have mocked up a rough tooltip using the cytoscape-cxtmenu extension used in factoid to just demonstrate the features potential use case. 

@jvwong @d2fong  @maxkfranz , any suggestions on potential design changes. 

![screen shot 2017-12-13 at 9 38 12 am](https://user-images.githubusercontent.com/1313810/33944355-e782be7e-dfe9-11e7-8574-2eddd901cb76.png)
 
Note : Merging this into the 'fun' branch just to seek feedback on the idea of having a context menu. 