### PR TITLE
Fixed React Warning

### DIFF
--- a/src/client/features/view/components/sidebar/menus/historyMenu.js
+++ b/src/client/features/view/components/sidebar/menus/historyMenu.js
@@ -29,6 +29,9 @@ class HistoryMenu extends React.Component {
       })
         //Obtain an image of each layout
         .then(() => {
+
+          if(!this.state || !this.state.layouts){return;}
+
           let graph = this.state.layouts.graph;
           let layouts = this.state.layouts.layout;
           


### PR DESCRIPTION
React threw a warning when a user tried to load the Sidebar before the graph was fully rendered. 
This one line change prevents react from attempting to load the sidebar contents, thus avoiding the warning