### PR TITLE
Changes to tooltips (Issue #473 and #466)

### DIFF
--- a/src/client/common/cy/events/click.js
+++ b/src/client/common/cy/events/click.js
@@ -3,7 +3,10 @@
 const hideTooltips = (cy) => {
   cy.elements().forEach(ele => {
     const tooltip = ele.scratch('_tooltip');
-    if (tooltip) { tooltip.hide(); }
+    if (tooltip) { 
+      tooltip.hide(); 
+      ele.scratch('_tooltip-opened', false);
+    }
   });
 };
 
@@ -14,6 +17,7 @@ const bindClick = (cy) => {
     const ele = evt.target;
 
     if (!ele.scratch('_tooltip-opened')) {
+      hideTooltips(cy);	
       ele.emit('showTooltip');
       ele.scratch('_tooltip-opened', true);
     } 

--- a/src/client/common/cy/events/index.js
+++ b/src/client/common/cy/events/index.js
@@ -7,7 +7,7 @@ const bindEvents = (cy,opts, callback) => {
   bindHover(cy);
   bindExpandCollapse(cy);
   bindClick(cy, callback);
-  bindShowTooltip(cy,opts.edgeTooltips);
+  bindShowTooltip(cy,opts.showTooltipsOnEdges);
 };
 
 module.exports = bindEvents;

--- a/src/client/common/cy/tooltips/format-content.js
+++ b/src/client/common/cy/tooltips/format-content.js
@@ -430,7 +430,7 @@ function generateDatabaseList(sortedArray, trim, expansionLink) {
   //Generate list
   let renderValue = sortedArray.map(item => [generateIdList(item, trim)], this);
 
-  return formatRenderValue(sortedArray,renderValue,expansionLink,trim,true);
+  return formatRenderValue(sortedArray,renderValue,expansionLink,trim,true,'Links');
 }
 
 function generateDetailedViewList(sortedArray, trim, expansionLink,maxViews) {
@@ -440,10 +440,10 @@ function generateDetailedViewList(sortedArray, trim, expansionLink,maxViews) {
   //Generate list
   let renderValue = list.map((data,index) => [generateDBLink(name, data, true,'Interaction '+(index+1))],this);
 
-  return formatRenderValue(sortedArray,renderValue,expansionLink,trim,false);
+  return formatRenderValue(sortedArray,renderValue,expansionLink,trim,false,'Detailed Views');
 }
 
-function formatRenderValue(sortedArray, renderValue, expansionLink, trim, list){
+function formatRenderValue(sortedArray, renderValue, expansionLink, trim, list,name){
   var hasMultipleIds = _.find(sortedArray, databaseRef => databaseRef.ids.length > 1);
   //Append expansion link to render value if one exists
   if (expansionLink && hasMultipleIds && trim) {
@@ -458,7 +458,7 @@ function formatRenderValue(sortedArray, renderValue, expansionLink, trim, list){
     renderValue = h('div.wrap-text', h('ul.db-list', renderValue));
   }
 
-  return h('div.fake-paragraph', [h('div.span-field-name', 'Detailed View:'), renderValue]);
+  return h('div.fake-paragraph', [h('div.span-field-name', name+':'), renderValue]);
 }
 
 module.exports = {

--- a/src/client/common/cy/tooltips/format-content.js
+++ b/src/client/common/cy/tooltips/format-content.js
@@ -42,12 +42,12 @@ const databaseHandler = (pair, expansionFunction) => {
 
 //Handle interaction/Detailed views related fields
 const interactionHandlerTrim =(pair, expansionFunction) => {
-  const expansionLink = h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »');
+  const expansionLink = pair[1].length>8? h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, 'more »'):'';
   if (pair[1].length < 1) { return h('div.error'); }
   return generateDatabaseList(sortByDatabaseId(pair[1]), true, expansionLink,'Detailed View', true);
 };
 const interactionHandler =(pair, expansionFunction) => {
-  const expansionLink = h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, '« less');
+  const expansionLink = pair[1].length>8? h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, '« less'):'';
   if (pair[1].length < 1) { return h('div.error'); }
   return generateDatabaseList(sortByDatabaseId(pair[1]), false, expansionLink,'Detailed View', true);
 };
@@ -270,15 +270,13 @@ function generateIdList(dbIdObject, trim, interactions) {
   let dbScan = db.filter(data => name.toUpperCase().indexOf(data[0].toUpperCase()) !== -1);
   if (dbScan.length > 0) { name = dbScan[0][0]; }
 
-  //Trim list
-  if (trim) { list = dbIdObject.ids.slice(0, 1); }
-
   //Generate a list or a single link
-  if (list.length == 1 && trim) {
-    return generateDBLink(name, list[0], true, interactions);
+  if (list.length >=  (interactions?8:1) && trim) {
+    list = dbIdObject.ids.slice(0, interactions?8:1);
+    return list.map((data, index) => generateDBLink(name, data, true, interactions, index), this);//generateDBLink(name, list[0], true, interactions);//
   }
   else {
-    return h('li.db-item', h('div.db-name', name + ": "), list.map((data, index) => generateDBLink(name, data, false, interactions, index), this));
+    return h('li.db-item', (interactions?'':h('div.db-name', name + ": ")), list.map((data, index) => generateDBLink(name, data, false, interactions, index), this));
   }
 }
 
@@ -305,7 +303,7 @@ function generateDBLink(dbName, dbId, isDbVisible, interactions, index) {
   if (isDbVisible) {
     className = '-single-ref';
   }
-  let label = isDbVisible ? dbName : (interactions ? 'Interaction '+(index+1):dbId);
+  let label = interactions ? 'Interaction '+(index+1):(isDbVisible ? dbName :dbId);
 
   //Build reference url
   if (link.length === 1 && link[0][1]) {

--- a/src/client/common/cy/tooltips/format-content.js
+++ b/src/client/common/cy/tooltips/format-content.js
@@ -272,11 +272,11 @@ function generateIdList(dbIdObject, trim) {
   let dbScan = db.filter(data => name.toUpperCase().indexOf(data[0].toUpperCase()) !== -1);
   if (dbScan.length > 0) { name = dbScan[0][0]; }
 
-  //Trim List
+  //Trim list
   if (trim) { list = dbIdObject.ids.slice(0, 1); }
 
   //Generate a list or a single link
-  if (list.length >= 1 && trim) {
+  if (list.length == 1 && trim) {
     return generateDBLink(name, list[0], true);
   }
   else {

--- a/src/client/common/cy/tooltips/index.js
+++ b/src/client/common/cy/tooltips/index.js
@@ -35,14 +35,15 @@ class MetadataTip {
 
       //If no tooltip exists create one
       if (!tooltip||(zoom!=cy.zoom()&&isEdge)) {
+        zoom=cy.zoom();
         //Generate HTML
-        let tooltipHTML = this.generateToolTip(callback);
-        let expandedHTML = this.generateExtendedToolTip(callback);
+        let tooltipHTML = this.generateToolTip(zoom,isEdge,callback);
+        let expandedHTML = this.generateExtendedToolTip(zoom,isEdge,callback);
 
         //Create tippy object
         let refObject = this.cyElement.popperRef();
-        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom', distance: isEdge? -25*cy.zoom()+7:10});
-        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom', distance: isEdge? -25*cy.zoom()+7:10 });
+        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom', distance: isEdge? -25*zoom+7:10});
+        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom', distance: isEdge? -25*zoom+7:10 });
         //Resolve Reference issues
         tooltip.selector.dim = refObject.dim;
         tooltip.selector.cyElement = refObject.cyElement;
@@ -51,7 +52,7 @@ class MetadataTip {
 
         //Save tooltips
         this.tooltip = tooltip;
-        this.zoom=cy.zoom();
+        this.zoom=zoom;
         this.tooltipExt = tooltipExt;
       }
 
@@ -70,7 +71,7 @@ class MetadataTip {
   }
 
   //Generate HTML Elements for tooltips
-  generateToolTip() {
+  generateToolTip(zoom,isEdge,callback) {
     //Order the data array
     let data = collection.toTop(this.data, config.tooltipOrder);
     data = collection.toBottom(data, config.tooltipReverseOrder);
@@ -83,7 +84,7 @@ class MetadataTip {
     this.validateName();
 
     //Generate the expand field option
-    const expandFunction = this.displayMore();
+    const expandFunction = this.displayMore(zoom,isEdge);
 
     if (!(this.data)) { this.data = []; }
     return h('div.tooltip-image', [
@@ -93,7 +94,7 @@ class MetadataTip {
   }
 
   //Generate HTML Elements for the side bar
-  generateExtendedToolTip() {
+  generateExtendedToolTip(zoom,isEdge,callback) {
     //Order the data array
     let data = collection.toTop(this.data, config.tooltipOrder);
     data = collection.toBottom(data, config.tooltipReverseOrder);
@@ -107,8 +108,8 @@ class MetadataTip {
     this.validateName();
 
     //Generate expansion and collapse functions 
-    const expandFunction = this.displayMore();
-    const collapseFunction = this.displayLess();
+    const expandFunction = this.displayMore(zoom,isEdge);
+    const collapseFunction = this.displayLess(zoom,isEdge);
 
     const getExpansionFunction = item => !this.isExpanded(item[0]) ? expandFunction : collapseFunction;
 
@@ -153,7 +154,7 @@ class MetadataTip {
   }
 
   //Display the expanded tooltip
-  expandToolTip(expansionObject, expansionField, fieldStatus) {
+  expandToolTip(expansionObject, expansionField, fieldStatus,zoom,isEdge) {
     //Modify view status
     expansionObject.viewStatus[expansionField] = fieldStatus;
 
@@ -163,7 +164,7 @@ class MetadataTip {
   
     //Get tooltip objects
     let tooltip = expansionObject.tooltip;
-    const expandedHTML = expansionObject.generateExtendedToolTip();
+    const expandedHTML = expansionObject.generateExtendedToolTip(zoom,isEdge);
 
     //Create tippy object
     let refObject = expansionObject.cyElement.popperRef();
@@ -175,9 +176,9 @@ class MetadataTip {
       arrow: true,
       position: 'bottom',
       animation: 'shift',
-      duration : 1
+      duration : 1,
+      distance: isEdge? -25*zoom+7:10
     });
-
 
     //Resolve Reference issues
     tooltipExt.selector.dim = refObject.dim;
@@ -192,15 +193,15 @@ class MetadataTip {
   }
 
   //Return a function that binds a tooltip to the expanded tooltip view
-  displayMore() {
+  displayMore(zoom,isEdge) {
     let that = this;
-    return (field) => that.expandToolTip(that, field, true);
+    return (field) => that.expandToolTip(that, field, true,zoom,isEdge);
   }
 
   //Return a function that binds an expanded tooltip to the minimized view.
-  displayLess() {
+  displayLess(zoom,isEdge) {
     let that = this;
-    return (field) => that.expandToolTip(that, field, false);
+    return (field) => that.expandToolTip(that, field, false,zoom,isEdge);
   }
 
   //Return the expansion status of a specified field

--- a/src/client/common/cy/tooltips/index.js
+++ b/src/client/common/cy/tooltips/index.js
@@ -24,6 +24,8 @@ class MetadataTip {
     //Get tooltip object from class
     let tooltip = this.tooltip;
     let tooltipExt = tooltip;
+    let zoom= this.zoom;
+    let isEdge=this.cyElement.isEdge();
 
     getPublications(this.data).then(function (data) {
       this.data = data;
@@ -32,15 +34,15 @@ class MetadataTip {
       this.hideAll(cy);
 
       //If no tooltip exists create one
-      if (!tooltip) {
+      if (!tooltip||(zoom!=cy.zoom()&&isEdge)) {
         //Generate HTML
         let tooltipHTML = this.generateToolTip(callback);
         let expandedHTML = this.generateExtendedToolTip(callback);
 
         //Create tippy object
         let refObject = this.cyElement.popperRef();
-        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom' });
-        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom' });
+        tooltip = tippy(refObject, { html: tooltipHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom', distance: isEdge? -25*cy.zoom()+7:10});
+        tooltipExt = tippy(refObject, { html: expandedHTML, theme: 'light', interactive: true, trigger: 'manual', hideOnClick: false, arrow: true, position: 'bottom', distance: isEdge? -25*cy.zoom()+7:10 });
         //Resolve Reference issues
         tooltip.selector.dim = refObject.dim;
         tooltip.selector.cyElement = refObject.cyElement;
@@ -49,6 +51,7 @@ class MetadataTip {
 
         //Save tooltips
         this.tooltip = tooltip;
+        this.zoom=cy.zoom();
         this.tooltipExt = tooltipExt;
       }
 

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -76,14 +76,18 @@ class Interactions extends React.Component {
     return hgncId;
   }
 
-  pathwayLinks(sources){
-    let links = [['Detailed views',[]],['Database IDs',[]]];//Format expected by format-content
-    sources.split(';').forEach( link => {
+  interactionMetadata(mediatorIds,pubmedIds){
+    let metadata = [['Detailed views',[]],['Database IDs',[]]];//Format expected by format-content
+    mediatorIds.split(';').forEach( link => {
       const splitLink=link.split('/');
       const view = splitLink[2]==='pathwaycommons.org';
-      view ? links[0][1].push(['Pathway Commons',splitLink[4]]) : links[1][1].push(['Reactome',splitLink[4]]);
+      view ? metadata[0][1].push(['Pathway Commons',splitLink[4]]) :
+        metadata[1][1].push(['Reactome',splitLink[4]]);
     });
-   return links;
+    if(pubmedIds){
+     pubmedIds.split(';').forEach(id=>metadata[1][1].push(['PubMed_Interactions',id]));
+    }
+   return metadata;
 }
 
   addInteraction(nodes,edge,sources,network,nodeMap,nodeMetadata){
@@ -97,6 +101,7 @@ class Interactions extends React.Component {
         ['Type','bp:'+metadata[0].split(' ')[0].replace(/Reference/g,'').replace(/;/g,',')],['Database IDs', links]]}});
       }
     });
+
     network.edges.push({data: {
       id: nodes[0]+'\t'+edge+'\t'+nodes[1] ,
       label: nodes[0]+' '+edge.replace(/-/g,' ')+' '+nodes[1] ,
@@ -117,7 +122,8 @@ class Interactions extends React.Component {
     const nodeMetadata= new Map(dataSplit[1].split('\n').slice(1).map(line =>line.split('\t')).map(line => [line[0], line.slice(1) ]));
     dataSplit[0].split('\n').slice(1).forEach(line => {
       const splitLine=line.split('\t');
-      this.addInteraction([splitLine[0],splitLine[2]],splitLine[1],this.pathwayLinks(splitLine[6]),network,nodeMap,nodeMetadata);
+      const edgeMetadata = this.interactionMetadata(splitLine[6],splitLine[4]);
+      this.addInteraction([splitLine[0],splitLine[2]],splitLine[1],edgeMetadata,network,nodeMap,nodeMetadata);
     });
     const id=this.findId(nodeMetadata,query);
     return {id,network};

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -77,11 +77,14 @@ class Interactions extends React.Component {
   }
 
   pathwayLinks(sources){
-    return sources.split(';').map( link => {
-      const splitLink=link.split('/').reverse();
-      return [splitLink[1]==='reactome'? 'reactome': 'Pathway Commons',splitLink[0]];
+    let links = [['Detailed views',[]],['Database IDs',[]]];//Format expected by format-content
+    sources.split(';').forEach( link => {
+      const splitLink=link.split('/');
+      const view = splitLink[2]==='pathwaycommons.org';
+      view ? links[0][1].push(['Pathway Commons',splitLink[4]]) : links[1][1].push(['Reactome',splitLink[4]]);
     });
-  }
+   return links;
+}
 
   addInteraction(nodes,edge,sources,network,nodeMap,nodeMetadata){
     const interaction= this.edgeType(edge);
@@ -100,7 +103,7 @@ class Interactions extends React.Component {
       source: nodes[0],
       target: nodes[1],
       class: interaction,
-      parsedMetadata:[['Database IDs',sources]]
+      parsedMetadata:sources
     },classes:interaction});
   }
 

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -152,7 +152,6 @@
 .wrap-text {
   word-wrap: break-word;
   overflow-y: auto;
- /* max-height: 300px;*/
   width: 100%;
 }
 
@@ -221,7 +220,6 @@
 
 .db-item {
   list-style-type: none;
-  margin: 0.05em 0em 0em 0em;
   word-wrap: break-word;
   line-height: 0.9em;
 }

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -152,7 +152,7 @@
 .wrap-text {
   word-wrap: break-word;
   overflow-y: auto;
-  max-height: 300px;
+ /* max-height: 300px;*/
   width: 100%;
 }
 
@@ -202,9 +202,11 @@
 
 .db-list {
   line-height: 0.2em;
+  margin: 0.2em 0em 0.2em 0em;
 }
 
 .db-link {
+  text-decoration: underline;
   color: var(--link);
   margin: 2px;
   font-weight: lighter;
@@ -218,6 +220,8 @@
 }
 
 .db-item {
+  list-style-type: none;
+  margin: 0.05em 0em 0em 0em;
   word-wrap: break-word;
   line-height: 0.9em;
 }


### PR DESCRIPTION
Includes changes from issue #473 and #466 and a bug that was noticed during work on these issues:
- Tool tips are now alway located close to the edge. Changes to tooltips.index, based the distance from the edge off of the current zoom which fixed the issue. 
- Noticed a bug in the behaviour of the tooltips. If the user clicked on a edge,node,edge or node,edge,node the new tooltip would not show. This was fixed by the changes made to click.js
- Put the Pathway Commons mediator ids to be under their own heading , 'Detailed Views',  this involved changes to format-content.js and a small change in interactions/index.js(changing metadata in interactionsMetadata)
- Added Pubmed links to edge tooltips using the Pubmed ids in the SIF file, changes made to interactions/index.js