### PR TITLE
Issue #515 fix

### DIFF
--- a/src/client/common/cy/match-style.js
+++ b/src/client/common/cy/match-style.js
@@ -8,8 +8,8 @@ const {applyStyle, removeStyle} = require('./manage-style');
 //Returns a list of strings
 const getNames = (node) => {
   const parsedMetadata = node.data('parsedMetadata');
+  const geneSynonyms = node.data('geneSynonyms');
   let label = [node.data('label')];
-
 
   if (!parsedMetadata) return label;
 
@@ -23,7 +23,7 @@ const getNames = (node) => {
   if (names.length > 0) { label = label.concat(names[0][1]); }
   if (displayName.length > 0) { label = label.concat(displayName[0][1]); }
 
-  label = label.concat(node.data('geneSynonyms'));
+  if(_.isArray(geneSynonyms)){label = label.concat(node.data('geneSynonyms'));}
 
   return _.compact(label);
 };
@@ -36,7 +36,7 @@ const evaluateNode = (node, matchingFn) => {
 
   //Check if any of the alternative names match the query
   for (var i = 0; i < namesList.length; i++) {
-    if (typeof namesList[i]==='string' && matchingFn(namesList[i])) {
+    if ( matchingFn(namesList[i]) ) {
       return true;
     }
   }

--- a/src/client/common/cy/match-style.js
+++ b/src/client/common/cy/match-style.js
@@ -36,7 +36,7 @@ const evaluateNode = (node, matchingFn) => {
 
   //Check if any of the alternative names match the query
   for (var i = 0; i < namesList.length; i++) {
-    if (matchingFn(namesList[i])) {
+    if (typeof namesList[i]==='string' && matchingFn(namesList[i])) {
       return true;
     }
   }


### PR DESCRIPTION
The issue in #515 was caused by inconsistent formats of geneSynonyms in the nodes data. On most networks geneSynonyms is stored as an array of strings (left as an empty array if none), on some it is left undefined and on others it is stored as an object (left as an empty array if none). This cassued the issue as it meant that .toUpperCase was called on a object instead of a string. 
The fix is to only concatenate geneSynonyms with label if it is an array.