### PR TITLE
Remove useless filter options

### DIFF
--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -95,19 +95,22 @@ class Interactions extends React.Component {
       const state = this.state;
       const cy = this.state.cy;
       const categories = state.categories;
-      _.forEach(state.buttonsClicked,(value,type)=>{
+      const buttonsClicked=state.buttonsClicked;
+      _.forEach(buttonsClicked,(value,type)=>{
         const edges = cy.edges().filter(`.${type}`);
         const nodes = edges.connectedNodes();
         categories.set(type,{
           edges:edges,
           nodes:nodes
         });
-        if(type != 'Binding'){
+        if(type != 'Binding' && nodes.length){
           this.filterUpdate(type);
         }
+        if(!nodes.length){buttonsClicked[type]='empty';}
       });
       this.setState({
-        categories:categories
+        categories:categories,
+        buttonsClicked:_.pickBy(buttonsClicked,_.isBoolean)
       });
       const initialLayoutOpts = state.layoutConfig.defaultLayout.options;
       const layout = cy.layout(initialLayoutOpts);
@@ -219,6 +222,7 @@ class Interactions extends React.Component {
   }
   render(){
     const state = this.state;
+    console.log(state.buttonsClicked);
     const baseView = h(BaseNetworkView.component, {
       layoutConfig: state.layoutConfig,
       componentConfig: state.componentConfig,

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -222,7 +222,6 @@ class Interactions extends React.Component {
   }
   render(){
     const state = this.state;
-    console.log(state.buttonsClicked);
     const baseView = h(BaseNetworkView.component, {
       layoutConfig: state.layoutConfig,
       componentConfig: state.componentConfig,


### PR DESCRIPTION
The filter options that would have no associated nodes/edges are not removed from the filter menu(issue #572 ).