### PR TITLE
allow emap to accept data with pathway ID

### DIFF
--- a/src/server/enrichment-map/emap/generateGraphInfo.js
+++ b/src/server/enrichment-map/emap/generateGraphInfo.js
@@ -17,11 +17,9 @@ const generateNodeInfo = require('./generateInfo').generateNodeInfo;
 const generateEdgeInfo = require('./generateInfo').generateEdgeInfo;
 const _ = require('lodash');
 
-
-// input ["GO:1902275", "GO:2001252", "GO:1905269", "GO:0051053"]
-// returns a cytoscape object
-const generateGraphInfo = (pathwayIdList, cutoff = 0.375, JCWeight, OCWeight) => {
-  if (cutoff < 0 || cutoff > 1) { throw new Error('ERROR: cutoff out of range [0, 1]');}
+// pathwayInfoList: {"GO:1":{pValue: 1}, "GO:2": {pValue: 0, color: "green"}}
+const generateGraphInfo = (pathwayInfoList, cutoff = 0.375, JCWeight, OCWeight) => {
+  if (cutoff < 0 || cutoff > 1) { throw new Error('ERROR: cutoff out of range [0, 1]'); }
   if (isNaN(Number(cutoff))) { throw new Error('ERROR: cutoff is not a number'); }
 
   if (JCWeight < 0 || JCWeight > 1) {
@@ -30,8 +28,8 @@ const generateGraphInfo = (pathwayIdList, cutoff = 0.375, JCWeight, OCWeight) =>
   if (OCWeight < 0 || OCWeight > 1) {
     throw new Error('ERROR: OCWeight out of range [0, 1]');
   }
-  if (JCWeight != undefined && isNaN(Number(JCWeight))) {throw new Error('ERROR: JCWeight should be a number');}
-  if (OCWeight != undefined && isNaN(Number(OCWeight))) {throw new Error('ERROR: OCWeight should be a number');}
+  if (JCWeight != undefined && isNaN(Number(JCWeight))) { throw new Error('ERROR: JCWeight should be a number'); }
+  if (OCWeight != undefined && isNaN(Number(OCWeight))) { throw new Error('ERROR: OCWeight should be a number'); }
   if (OCWeight != undefined && JCWeight != undefined && Number(OCWeight) + Number(JCWeight) != 1) {
     throw new Error('ERROR: OCWeight + JCWeight should be 1');
   }
@@ -46,31 +44,31 @@ const generateGraphInfo = (pathwayIdList, cutoff = 0.375, JCWeight, OCWeight) =>
 
   // check unrecognized and duplicates, modify pathwayIdList
   const unrecognized = [];
-  for (let i = 0; i < pathwayIdList.length; ++i) {
-    const pathwayId = pathwayIdList[i];
+  console.log(pathwayInfoList);
+  console.log(typeof(pathwayInfoList));
+  for (let pathwayId in pathwayInfoList) {
+    if (!pathwayInfoList.hasOwnProperty(pathwayId)) continue;
+    //console.log(pathwayId);
     if (!pathwayInfoTable.has(pathwayId)) {
       if (_.filter(unrecognized, elem => elem === pathwayId).length === 0) {
         unrecognized.push(pathwayId);
       }
-      pathwayIdList.splice(pathwayIdList.indexOf(pathwayId), 1);
-      --i;
+      delete pathwayInfoList[pathwayId];
+    } else if (pathwayInfoList[pathwayId].hasOwnProperty('pathwayId')) {
+      throw new Error('ERROR: additional info for ' + pathwayId + ' can not have pathwayId field');
     }
   }
-  for (let i = 0; i < pathwayIdList.length; ++i) {
-    const pathwayId = pathwayIdList[i];
-    if ((_.filter(pathwayIdList, ele => ele === pathwayId)).length > 1) {
-      throw new Error('ERROR: ' + pathwayId + ' is a duplicate');
-    }
+  const pathwayIdList = [];
+  for (let pathwayId in pathwayInfoList) {
+    if (!pathwayInfoList.hasOwnProperty(pathwayId)) continue;
+    pathwayIdList.push(pathwayId);
   }
   // generate node and edge info
   const elements = [];
-  const cytoscapeJSON = {};
-  cytoscapeJSON.nodes = [];
-  cytoscapeJSON.edges = [];
-  const nodeInfo = generateNodeInfo(pathwayIdList);
-  _.forEach(nodeInfo, node => {
-    elements.push({ data: { id: node.pathwayId } });
-  });
+  for (let pathwayId in pathwayInfoList) {
+    if (!pathwayInfoList.hasOwnProperty(pathwayId)) continue;
+    elements.push({ data: _.assign({ id: pathwayId }, pathwayInfoList[pathwayId]) })
+  }
   const edgeInfo = generateEdgeInfo(pathwayIdList, JCWeight, cutoff);
   _.forEach(edgeInfo, edge => {
     const sourceIndex = 0;

--- a/src/server/enrichment-map/emap/generateGraphInfo.js
+++ b/src/server/enrichment-map/emap/generateGraphInfo.js
@@ -44,11 +44,8 @@ const generateGraphInfo = (pathwayInfoList, cutoff = 0.375, JCWeight, OCWeight) 
 
   // check unrecognized and duplicates, modify pathwayIdList
   const unrecognized = [];
-  console.log(pathwayInfoList);
-  console.log(typeof(pathwayInfoList));
   for (let pathwayId in pathwayInfoList) {
     if (!pathwayInfoList.hasOwnProperty(pathwayId)) continue;
-    //console.log(pathwayId);
     if (!pathwayInfoTable.has(pathwayId)) {
       if (_.filter(unrecognized, elem => elem === pathwayId).length === 0) {
         unrecognized.push(pathwayId);


### PR DESCRIPTION
related #563
changed input format to generateGraphInfo to the same as the output of enrichment service
e.g.
```
{
		"GO:0006354": {
			"pValue": 1,
			"t": 124
		},
		"GO:0006368": {
			"pValue": 0.999,
			"t": 100,
			"q": 1,
			"qAndT": 1,
			"qAndTOverQ": 1,
			"qAndTOverT": 0.01,
			"tType": "BP",
			"tGroup": 5,
			"tName": "transcription elongation from RNA polymerase II promoter",
			"tDepth": 1,
			"qAndTList": [
				"AFF4"
			]
		}
}
```

