### PR TITLE
Reactome MEDIATOR_IDS included in 'Detailed Views'

### DIFF
--- a/src/client/common/cy/tooltips/format-content.js
+++ b/src/client/common/cy/tooltips/format-content.js
@@ -441,7 +441,11 @@ function generateDetailedViewList(sortedArray, trim, expansionLink, maxViews, ti
   let renderValue = list.map((data,index) => [h('div.fake-spacer', 
     h('a.db-link' ,{
       href:'/view?',
-      search: queryString.stringify({uri:'http://pathwaycommons.org/pc2/'+data, title:title, removeInfoMenu:true}),
+      search: queryString.stringify({
+        uri:(data.startsWith('R')?'http://identifiers.org/reactome/':'http://pathwaycommons.org/pc2/')+data, 
+        title:title, 
+        removeInfoMenu:true
+      }),
       target: '_blank', 
     }, 'Interaction '+(index+1))
   )]);

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -145,10 +145,7 @@ class Interactions extends React.Component {
   interactionMetadata(mediatorIds,pubmedIds){
     let metadata = [['Detailed views',[]],['Database IDs',[]]];//Format expected by format-content
     mediatorIds.split(';').forEach( link => {
-      const splitLink=link.split('/');
-      const view = splitLink[2]==='pathwaycommons.org';
-      view ? metadata[0][1].push(['Pathway Commons',splitLink[4]]) :
-        metadata[1][1].push(['Reactome',splitLink[4]]);
+        metadata[0][1].push(['Interaction',link.split('/')[4]]);
     });
     if(pubmedIds){
      pubmedIds.split(';').forEach(id=>metadata[1][1].push(['PubMed_Interactions',id]));


### PR DESCRIPTION
Moved Reactome MEDIATOR_IDS to be included in 'Detailed Views' as discussed in issue #606.