### PR TITLE
Fully Updated Landing Box and Interaction Viewer

### DIFF
--- a/src/client/common/config.js
+++ b/src/client/common/config.js
@@ -22,7 +22,9 @@ const databases = [
   ['Chemical Component Dictionary', 'http://identifiers.org/pdb-ccd/', ''],
   ['CAS', 'http://identifiers.org/cas/', ''],
   ['HPRD','	http://identifiers.org/hprd/',''],
-  ['RefSeq','	http://identifiers.org/refseq/','']
+  ['RefSeq','	http://identifiers.org/refseq/',''],
+  ['NCBI Gene','http://identifiers.org/ncbigene/',''],
+  ['Gene Cards','http://identifiers.org/genecards/','']
 ];
 
 const publicationsURL = 'http://identifiers.org/pubmed/';

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -90,7 +90,7 @@ class Interactions extends React.Component {
     this.state.cy.on('trim', () => {
       const state = this.state;
       const ids = state.ids;
-      if(ids.length>0){
+      if(ids.length===query.id.length){
         const cy = state.cy;
         const mainNode = cy.nodes(node=> ids.indexOf(node.data().id) != -1);
         const nodesToKeep = mainNode.merge(mainNode.connectedEdges().connectedNodes());
@@ -137,17 +137,6 @@ class Interactions extends React.Component {
       default:
         return '';
     }
-  }
-
-  findId(data,ids){
-    let hgncId=[];
-    const idTest=new RegExp(ids.join("|"));
-    data.forEach((value,key)=> {
-      if (idTest.test(value[2])){
-        hgncId.push(key); 
-      }
-    });
-    return hgncId;
   }
 
   interactionMetadata(mediatorIds,pubmedIds){

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -66,7 +66,7 @@ class Interactions extends React.Component {
           name: (network.id.join(' , ')+' Interactions'),
           datasource: 'Pathway Commons',
         }),
-        id: network.id,
+        id:geneQueryResult.geneInfo[0].convertedAlais ,
         loading: false
       }); 
       
@@ -180,7 +180,7 @@ class Interactions extends React.Component {
     },classes:interaction});
   }
 
-  parse(data,query){
+  parse(data){
     let network = {
       edges:[],
       nodes:[],

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -73,7 +73,7 @@ class Interactions extends React.Component {
         hgncIds.push(geneResults[gene].name);
         return _.compact([
           'Nomenclature Name: '+geneResults[gene].nomenclaturename,
-          'Synonyms: '+geneResults[gene].name+', '+geneResults[gene].otheraliases,
+          'Other Aliases: '+geneResults[gene].name + (geneResults[gene].otheraliases ? ', '+geneResults[gene].otheraliases:''),
           geneResults[gene].summary&&'Function: '+geneResults[gene].summary
         ]);
       }));

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -236,7 +236,7 @@ class Interactions extends React.Component {
         promise: () => Promise.resolve(_.map(state.cy.edges(),edge=> edge.data().id).sort().join('\n'))
       },
     }):
-    h('div..no-network',[h('strong.title','No interactions to display'),h('span','Return to the previous page and try a diffrent set of entities')]);
+    h('div.no-network',[h('strong.title','No interactions to display'),h('span','Return to the previous page and try a diffrent set of entities')]);
 
     const loadingView = h(Loader, { loaded: !state.loading, options: { left: '50%', color: '#16A085' }});
 

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -54,7 +54,7 @@ class Interactions extends React.Component {
     };    
 
     const query = queryString.parse(props.location.search);
-    if(query.id.constructor != Array){query.id=[query.id];}
+    query.id=_.concat([],query.id);
       ServerAPI.getNeighborhood(query.id,query.kind).then(res=>{ 
       const layoutConfig = getLayoutConfig('interactions');
       const network= this.parse(res,query.id);

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -100,7 +100,7 @@ class Search extends React.Component {
                 id:gene,
                 name:geneResults[gene].nomenclaturename,
                 function: geneResults[gene].summary,
-                synonyms: geneResults[gene].name+', '+geneResults[gene].otheraliases,
+                synonyms: geneResults[gene].name + (geneResults[gene].otheraliases ? ', '+geneResults[gene].otheraliases:''),
                 showMore:{full:!(geneResults.uids.length>1),function:false,synonyms:false},
                 links:links
               };
@@ -264,7 +264,7 @@ class Search extends React.Component {
             h(Link, { 
               to: { pathname: '/interactions',search: queryString.stringify({ id: box.id, kind:'NEIGHBORHOOD' })}, 
               target: '_blank', className: 'search-landing-interactions', key:'interactions' 
-            }, [h('button.search-landing-button', `View Interactions With ${box.name}`)])
+            }, [h('button.search-landing-button', `View Interactions`)])
           ])
         ];    
       });

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -239,44 +239,42 @@ class Search extends React.Component {
         if(multipleBoxes){
           title.push(h('strong.material-icons',{key:'arrow'},state.landing[index].showMore.full? 'expand_less': 'expand_more'));
         }
-
         let synonyms=[];
         if(box.synonyms){ 
           synonyms=expandableText(112, box.synonyms,',','i','search-landing-small','synonyms',index);
         }
-
         let functions=[];
         if(box.function){
           functions=expandableText(260, box.function,' ','span','search-landing-function','function',index);
         } 
-
         let links=[];
         _.forIn((box.links),(value,key)=>{
           links.push(h('a.search-landing-link',{key: key, href: value},key));
         });
-
         return [ 
           h('div.search-landing-title',{key:'title',
             onClick: () => {if(multipleBoxes){handelShowMoreClick('full',index);}},
             className:classNames('search-landing-title',{'search-landing-title-multiple':multipleBoxes}),
-            },[title]),  
+          },[title]),
           box.showMore.full && 
           h('div.search-landing-innner',{key: box.id},[ 
-          h('div.search-landing-section',{key: 'synonyms'},[synonyms]),
-          h('div.search-landing-section',{key: 'functions'},[functions]),
-          h('div.search-landing-section',{key: 'links'},[links]),
-
-          h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: box.id, kind:'NEIGHBORHOOD' })}, 
-            target: '_blank',className: 'search-landing-interactions', key:'interactions' }, [
-            h('button.search-landing-button', `View Interactions With ${box.name}`),
-          ])])
+            h('div.search-landing-section',{key: 'synonyms'},[synonyms]),
+            h('div.search-landing-section',{key: 'functions'},[functions]),
+            h('div.search-landing-section',{key: 'links'},[links]),
+            h(Link, { 
+              to: { pathname: '/interactions',search: queryString.stringify({ id: box.id, kind:'NEIGHBORHOOD' })}, 
+              target: '_blank', className: 'search-landing-interactions', key:'interactions' 
+            }, [h('button.search-landing-button', `View Interactions With ${box.name}`)])
+          ])
         ];    
       });
       if(state.landing.length>1 && !state.landingLoading){
-        landing.push(h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: state.landing.map(entry=>entry.id), kind:'PATHSBETWEEN' })}, 
-        target: '_blank',className: 'search-landing-interactions', key:'interactions' }, [
-        h('button.search-landing-button', 'View Interactions Between Entities'),
-      ]));
+        landing.push(
+          h(Link, { 
+            to: { pathname: '/interactions',search: queryString.stringify({ id: state.landing.map(entry=>entry.id), kind:'PATHSBETWEEN' })}, 
+            target: '_blank', className: 'search-landing-interactions', key:'interactions' 
+          }, [h('button.search-landing-button', 'View Interactions Between Entities')])
+        );
       }
 
     return h('div.search', [

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -253,11 +253,18 @@ class Search extends React.Component {
           h('div.search-landing-section',{key: 'synonyms'},[synonyms]),
           h('div.search-landing-section',{key: 'functions'},[functions]),
           h('div.search-landing-section',{key: 'links'},[links]),
-          h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ ID: box.accession })}, 
+          h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: box.accession, kind:'NEIGHBORHOOD' })}, 
             target: '_blank',className: 'search-landing-interactions', key:'interactions' }, [
-            h('button.search-landing-button', 'View Interactions'),
-          ])]) 
-        ];});
+            h('button.search-landing-button', `View Interactions With ${box.name}`),
+          ])])
+        ];    
+      });
+      if(state.landing.length>1 && !state.landingLoading){
+        landing.push(h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: state.landing.map(entry=>entry.accession), kind:'PATHSBETWEEN' })}, 
+        target: '_blank',className: 'search-landing-interactions', key:'interactions' }, [
+        h('button.search-landing-button', 'View Interactions Between Entities'),
+      ]));
+      }
 
     return h('div.search', [
       h('div.search-header-container', [

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -90,14 +90,14 @@ class Search extends React.Component {
         if(!_.isEmpty(ids)){
           ServerAPI.getGeneInformation(ids,'gene').then(result=>{
             const geneResults=result.result;
-            landing = geneResults.uids.map((gene)=>{
+            landing = geneResults.uids.map(gene=>{
               const originalSearch = _.findKey(genes,entry=> entry['NCBI Gene']===gene);
               const links=_.mapValues(genes[originalSearch],(value,key)=>{
                 let link = databases.filter(databaseValue => key.toUpperCase() === databaseValue[0].toUpperCase());
                 return link[0][1] + link[0][2] + value;
               });
               return {
-                originalSearch:originalSearch,
+                id:gene,
                 name:geneResults[gene].nomenclaturename,
                 function: geneResults[gene].summary,
                 synonyms: geneResults[gene].name+', '+geneResults[gene].otheraliases,
@@ -261,19 +261,19 @@ class Search extends React.Component {
             className:classNames('search-landing-title',{'search-landing-title-multiple':multipleBoxes}),
             },[title]),  
           box.showMore.full && 
-          h('div.search-landing-innner',{key: box.originalSearch},[ 
+          h('div.search-landing-innner',{key: box.id},[ 
           h('div.search-landing-section',{key: 'synonyms'},[synonyms]),
           h('div.search-landing-section',{key: 'functions'},[functions]),
           h('div.search-landing-section',{key: 'links'},[links]),
 
-          h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: box.originalSearch, kind:'NEIGHBORHOOD' })}, 
+          h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: box.id, kind:'NEIGHBORHOOD' })}, 
             target: '_blank',className: 'search-landing-interactions', key:'interactions' }, [
             h('button.search-landing-button', `View Interactions With ${box.name}`),
           ])])
         ];    
       });
       if(state.landing.length>1 && !state.landingLoading){
-        landing.push(h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: state.landing.map(entry=>entry.accession), kind:'PATHSBETWEEN' })}, 
+        landing.push(h(Link, { to: { pathname: '/interactions',search: queryString.stringify({ id: state.landing.map(entry=>entry.id), kind:'PATHSBETWEEN' })}, 
         target: '_blank',className: 'search-landing-interactions', key:'interactions' }, [
         h('button.search-landing-button', 'View Interactions Between Entities'),
       ]));

--- a/src/client/features/search/landing-box.js
+++ b/src/client/features/search/landing-box.js
@@ -1,0 +1,149 @@
+const h = require('react-hyperscript');
+const Link = require('react-router-dom').Link;
+const classNames = require('classnames');
+const queryString = require('query-string');
+const { ServerAPI } = require('../../services');
+const databases = require('../../common/config').databases;
+const Loader = require('react-loader');
+const _ = require('lodash');
+
+const linkBuilder= (source,array)=>{
+  let genes={};
+  array.forEach(gene=>{
+    genes[gene.initialAlias]={[source]:gene.convertedAlias};
+  });
+  return genes;
+};
+
+/*Gets info for a landing box
+input: 'TP53'
+output: [{
+function:"This gene encodes ..."
+id:"7157"
+links:{Gene Cards:"http://identifiers.org/genecards/TP53"...}
+name:"tumor protein p53"
+showMore:{full:false,function:false,synonyms:false}
+synonyms:"TP53, BCC7, LFS1, P53, TRP53"
+}]
+*/
+const getLandingResult= (query)=> {
+  const q=query.trim();
+  return Promise.all([
+    ServerAPI.geneQuery({genes: q,target: 'ENTREZGENE_ACC'}).then(result=>linkBuilder('NCBI Gene',result.geneInfo)),
+    ServerAPI.geneQuery({genes: q,target: 'UNIPROT'}).then(result=>linkBuilder('Uniprot',result.geneInfo)),
+    ServerAPI.geneQuery({genes: q,target: 'HGNC'}).then(result=>linkBuilder('HGNC',result.geneInfo)),
+    ServerAPI.geneQuery({genes: q,target: 'HGNCSYMBOL'}).then(result=>linkBuilder('Gene Cards',result.geneInfo)),
+  ]).then(values=>{let genes=values[0];
+    _.tail(values).forEach(gene=>_.mergeWith(genes,gene,(objValue, srcValue)=>_.assign(objValue,srcValue)));
+      let ids=[];
+      _.forEach(genes,gene=>{
+        ids.push(gene['NCBI Gene']);
+      });
+       if(!_.isEmpty(ids)){
+         return ServerAPI.getGeneInformation(ids,'gene').then(result=>{
+          const geneResults=result.result;
+          return geneResults.uids.map(gene=>{
+            const originalSearch = _.findKey(genes,entry=> entry['NCBI Gene']===gene);
+            const links=_.mapValues(genes[originalSearch],(value,key)=>{
+              let link = databases.filter(databaseValue => key.toUpperCase() === databaseValue[0].toUpperCase());
+              return link[0][1] + link[0][2] + value;
+            });
+            return {
+              id:gene,
+              name:geneResults[gene].nomenclaturename,
+              function: geneResults[gene].summary,
+              synonyms: geneResults[gene].name + (geneResults[gene].otheraliases ? ', '+geneResults[gene].otheraliases:''),
+              showMore:{full:!(geneResults.uids.length>1),function:false,synonyms:false},
+              links:links
+            };
+          });
+        });
+       }
+       else{
+        return [];
+      }
+  });
+};
+
+const handelShowMoreClick= (controller,landing,varToToggle,index) => {
+  landing[index].showMore[varToToggle]=!landing[index].showMore[varToToggle];
+  controller.setState({ landing:landing }); 
+};
+
+const expandableText = (controller,landing,length,text,charToCutOn,type,cssClass,toggleVar,index)=>{
+  let result = null;
+  const varToToggle= landing[index].showMore[toggleVar];
+  const textToUse= (varToToggle|| text.length<=length)?
+    text+' ': text.slice(0,text.lastIndexOf(charToCutOn,length))+' '; 
+    result=[h(`${type}`,{className:cssClass,key:'text'},textToUse)];
+  if(text.length>length){
+    result.push(h(`${type}.search-landing-link`,{onClick: ()=> handelShowMoreClick(controller, landing, toggleVar, index),key:'showMore'},
+    varToToggle ? '« less': 'more »'));
+  }
+  return result;
+};
+
+/*Generates a landing box
+input: {controller,[{
+function:"This gene encodes ..."
+id:"7157"
+links:{Gene Cards:"http://identifiers.org/genecards/TP53"...}
+name:"tumor protein p53"
+showMore:{full:false,function:false,synonyms:false}
+synonyms:"TP53, BCC7, LFS1, P53, TRP53"
+}]}
+output: html for a landing box
+*/
+const landingBox = (props) => {
+  const landing=props.landing;
+  const controller=props.controller;
+  if (controller.state.landingLoading ) {
+    return h('div.search-landing-innner',[h(Loader, { loaded:false , options: { color: '#16A085', position:'relative', top: '15px' }})]);
+  }
+  const landingHTML= landing.map((box,index)=>{
+    const multipleBoxes = landing.length>1;
+    const title = [h('strong.search-landing-title-text',{key:'name'},box.name),];
+    if(multipleBoxes){
+      title.push(h('strong.material-icons',{key:'arrow'},landing[index].showMore.full? 'expand_less': 'expand_more'));
+    }
+    let synonyms=[];
+    if(box.synonyms){ 
+      synonyms=expandableText(controller,landing,112, box.synonyms,',','i','search-landing-small','synonyms',index);
+    }
+    let functions=[];
+    if(box.function){
+      functions=expandableText(controller,landing,260, box.function,' ','span','search-landing-function','function',index);
+    } 
+    let links=[];
+    _.forIn((box.links),(value,key)=>{
+      links.push(h('a.search-landing-link',{key: key, href: value},key));
+    });
+    return [ 
+      h('div.search-landing-title',{key:'title',
+        onClick: () => {if(multipleBoxes){handelShowMoreClick(controller,landing, 'full', index);}},
+        className:classNames('search-landing-title',{'search-landing-title-multiple':multipleBoxes}),
+      },[title]),
+      box.showMore.full && 
+      h('div.search-landing-innner',{key: box.id},[ 
+        h('div.search-landing-section',{key: 'synonyms'},[synonyms]),
+        h('div.search-landing-section',{key: 'functions'},[functions]),
+        h('div.search-landing-section',{key: 'links'},[links]),
+        h(Link, { 
+          to: { pathname: '/interactions',search: queryString.stringify({ id: box.id, kind:'NEIGHBORHOOD' })}, 
+          target: '_blank', className: 'search-landing-interactions', key:'interactions' 
+        }, [h('button.search-landing-button', `View Interactions`)])
+      ])
+    ];    
+  });
+  if(landing.length>1){
+    landingHTML.push(
+      h(Link, { 
+        to: { pathname: '/interactions',search: queryString.stringify({ id:landing.map(entry=>entry.id), kind:'PATHSBETWEEN' })}, 
+        target: '_blank', className: 'search-landing-interactions', key:'interactions' 
+      }, [h('button.search-landing-button', 'View Interactions Between Entities')])
+    );
+  }
+  return landingHTML;
+};
+
+module.exports = {getLandingResult,landingBox};

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -35,10 +35,11 @@ const ServerAPI = {
   getProteinInformation(uniprotId){
     return fetch(`https://www.ebi.ac.uk/proteins/api/proteins?offset=0&accession=${uniprotId}`,defaultFetchOpts).then(res => res.json());
   },
-  
-  getNeighborhood(uniprotId,format){
-    return fetch(`http://www.pathwaycommons.org/pc2/graph?source=http://identifiers.org/uniprot/${uniprotId}&kind=neighborhood&format=${format}&pattern=controls-phosphorylation-of
-  &pattern=in-complex-with&pattern=controls-expression-of&pattern=interacts-with`,defaultFetchOpts).then(res => res.text());
+
+  getNeighborhood(ids,kind){
+   const source=ids.map(id=>`source=http://identifiers.org/uniprot/${id}`).join('&');
+    return fetch(`http://www.pathwaycommons.org/pc2/graph?${source}&kind=${kind}&format=TXT&pattern=controls-phosphorylation-of
+      &pattern=in-complex-with&pattern=controls-expression-of&pattern=interacts-with`,defaultFetchOpts).then(res => res.text());
   },
 
   // Send a diff in a node to the backend. The backend will deal with merging these diffs into

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -37,7 +37,7 @@ const ServerAPI = {
   },
 
   getNeighborhood(ids,kind){
-   const source=ids.map(id=>`source=http://identifiers.org/uniprot/${id}`).join('&');
+   const source=ids.map(id=>`source=${id}`).join('&');
     return fetch(`http://www.pathwaycommons.org/pc2/graph?${source}&kind=${kind}&format=TXT&pattern=controls-phosphorylation-of
       &pattern=in-complex-with&pattern=controls-expression-of&pattern=interacts-with`,defaultFetchOpts).then(res => res.text());
   },

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -33,7 +33,7 @@ const ServerAPI = {
   },
 
   getProteinInformation(uniprotId){
-    return fetch(`https://www.ebi.ac.uk/proteins/api/proteins?offset=0&size=1&accession=${uniprotId}`,defaultFetchOpts).then(res => res.json());
+    return fetch(`https://www.ebi.ac.uk/proteins/api/proteins?offset=0&accession=${uniprotId}`,defaultFetchOpts).then(res => res.json());
   },
   
   getNeighborhood(uniprotId,format){

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -38,8 +38,8 @@ const ServerAPI = {
 
   getNeighborhood(ids,kind){
    const source=ids.map(id=>`source=${id}`).join('&');
-    return fetch(`http://www.pathwaycommons.org/pc2/graph?${source}&kind=${kind}&format=TXT&pattern=controls-phosphorylation-of
-      &pattern=in-complex-with&pattern=controls-expression-of&pattern=interacts-with`,defaultFetchOpts).then(res => res.text());
+   const patterns = '&pattern=controls-phosphorylation-of&pattern=in-complex-with&pattern=controls-expression-of&pattern=interacts-with';
+    return fetch(`http://www.pathwaycommons.org/pc2/graph?${source}&kind=${kind}&format=TXT${patterns}`,defaultFetchOpts).then(res => res.text());
   },
 
   // Send a diff in a node to the backend. The backend will deal with merging these diffs into

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -32,8 +32,8 @@ const ServerAPI = {
     return fetch(`/api/gene-query?${qs.stringify(query)}`, defaultFetchOpts).then(res => res.json());
   },
 
-  getProteinInformation(uniprotId){
-    return fetch(`https://www.ebi.ac.uk/proteins/api/proteins?offset=0&accession=${uniprotId}`,defaultFetchOpts).then(res => res.json());
+  getGeneInformation(ids,type){
+    return fetch(`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?retmode=json&db=${type}&id=${ids.join(',')}`, {method: 'GET'}).then(res => res.json());
   },
 
   getNeighborhood(ids,kind){

--- a/src/styles/features/interactions.css
+++ b/src/styles/features/interactions.css
@@ -1,0 +1,23 @@
+.no-network{
+align-self: center; 
+display: flex;
+flex-direction: column;
+align-items: center;
+justify-content: center;
+margin:0 auto;
+max-width: var(--search-width);
+width: 100%;
+height:80px;
+background-color: var(--light-base-colour-dark);
+}
+
+.title{
+  font-size: 2em;
+}
+
+
+.main{
+  display: flex;
+  width: 100vw;
+  height:100vh;
+}

--- a/src/styles/features/search.css
+++ b/src/styles/features/search.css
@@ -262,6 +262,10 @@
   border-bottom:1px var(--light-base-colour-darker) solid;
 }
 
+.search-landing-title-text{
+  text-transform: capitalize;
+}
+
 .search-landing-title-multiple{
   cursor:pointer;
 }

--- a/src/styles/features/search.css
+++ b/src/styles/features/search.css
@@ -221,19 +221,25 @@
   text-overflow: ellipsis;
 }
 .search-landing{
-  width: 100%;
-}
-
-.search-landing.innner{
-  margin-top: 20px;
-  padding:10px;
   max-width: var(--search-width);
   width: 100%;
-  min-height: 30px;
+  background-color: var(--light-base-colour);
+  margin-top: 20px;
+}
+
+.search-landing-innner{
+  box-sizing: border-box;
+  margin-bottom: 1px;
+  border:1px var(--light-base-colour-dark) solid;
+  padding:10px;
+  padding-top: 5px;
+  max-width: var(--search-width);
+  width: 100%;
+  min-height: 50px;
   background-color: var(--light-base-colour);
   display: flex;
-  vertical-align: middle; 
-  justify-content: space-between;
+  vertical-align: center;
+  justify-content: baseline;
   flex-direction: column;
 }
 
@@ -251,6 +257,17 @@
 
 .search-landing-title{
   font-size: 15pt;
+  padding:10px;
+  background-color: var(--light-base-colour-dark);
+  border-bottom:1px var(--light-base-colour-darker) solid;
+}
+
+.search-landing-title-multiple{
+  cursor:pointer;
+}
+
+.search-landing-title:last-of-type{
+  border-bottom-width:0px
 }
 
 .search-landing-link {
@@ -265,7 +282,6 @@
 }
 
 .search-landing-button{
-
   background-color: #0073BF;
   color: white;
   border-radius: 0px;
@@ -280,10 +296,12 @@
   background-color: #6E9ABD; 
   color: white;
 }
+
 .search-landing-interactions {
   margin-top: 5px;
   width: 100%;
 }
+
 .search-item {
   display: flex;
   vertical-align: middle; 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -11,3 +11,4 @@
 @import "./features/search.css";
 @import "./features/paint.css";
 @import "./features/view.css";
+@import "./features/interactions.css";


### PR DESCRIPTION
I made a branch and merged all the changes I had that where waiting for PRs into 1 branch.  There is no need to merge PR #608 if we merge this.
Changes in this PR as a full are:
- Support case where user enters more than 1 recognized gene with both the landing box and interaction viewer (issue #520)
- Move away from uniprot dependency to support wider range of genes by changing database used by landing box (issue #574).
- Refactor landing box into separate component (issue #627)

Changes to interactions/index.js:
- All networkMetadata now fetched by ServerAPI. getGeneInformation
- Only trim the network if the number of found ids = to the number of quired genes (this stops the case where the quried gene may be removed by trimming)
- findId() removed and changes to parse are because ids are now found in ServerAPI. getGeneInformation
 - Add message when no network is found (sometimes PathsBetween does not return a network)

Changes to search/index.js:
- Removed code dealing with the landing box

Changes to search/landing.js (apart from creating it):
- logic of getLandingResult() changed to handle NCBI database
  - get database ids of genes searched  ( all but ENTREZGENE_ACC are just used for links)->merge all the ids in to a easy to use object-> if there are ids get gene information from NCBI with ENTREZGENE_ACC-> format the returned content into a easy to use object
- handelShowMoreClick and expandableText added to cut down on repeated code
- landing box no longer handles extraction of useful bits from fetched data (handled by getLandingResults)
