### PR TITLE
Always show the landing box and change to how the initial trim is done.

### DIFF
--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -106,18 +106,15 @@ class Interactions extends React.Component {
       _.forEach(buttonsClicked,(value,type)=>{
         const edges = cy.edges().filter(`.${type}`);
         const nodes = edges.connectedNodes();
-        categories.set(type,{
-          edges:edges,
-          nodes:nodes
-        });
-        if(type != 'Binding' && nodes.length){
-          this.filterUpdate(type);
-        }
-        if(!nodes.length){buttonsClicked[type]='empty';}
+        edges.length?
+        categories.set(type,{edges:edges,nodes:nodes}):
+        (categories.delete(type),delete buttonsClicked[type]);      
       });
+
+      _.tail(_.toPairs(buttonsClicked)).map(pair=>this.filterUpdate(pair[0]));
       this.setState({
         categories:categories,
-        buttonsClicked:_.pickBy(buttonsClicked,_.isBoolean)
+        buttonsClicked:buttonsClicked
       });
       const initialLayoutOpts = state.layoutConfig.defaultLayout.options;
       const layout = cy.layout(initialLayoutOpts);

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -218,7 +218,7 @@ class Search extends React.Component {
       h(Loader, { loaded: !state.loading, options: { left: '50%', color: '#16A085' } }, [
         h('div.search-list-container', [
           h('div.search-result-info', [searchResultInfo]),
-          h('div.search-landing',[searchResults.length ? h(landingBox,{controller,landing}):'']), 
+          h(landingBox,{controller,landing}), 
           h('div.search-list', searchResults)
         ])
       ])

--- a/src/client/features/search/landing-box.js
+++ b/src/client/features/search/landing-box.js
@@ -98,7 +98,11 @@ const landingBox = (props) => {
   const landing=props.landing;
   const controller=props.controller;
   if (controller.state.landingLoading ) {
-    return h('div.search-landing-innner',[h(Loader, { loaded:false , options: { color: '#16A085', position:'relative', top: '15px' }})]);
+    return h('div.search-landing', 
+      h('div.search-landing-innner',
+        h(Loader, { loaded:false , options: { color: '#16A085', position:'relative', top: '15px' }})
+      )
+    );
   }
   const landingHTML= landing.map((box,index)=>{
     const multipleBoxes = landing.length>1;
@@ -143,7 +147,7 @@ const landingBox = (props) => {
       }, [h('button.search-landing-button', 'View Interactions Between Entities')])
     );
   }
-  return landingHTML;
+  return h('div.search-landing',landingHTML);
 };
 
 module.exports = {getLandingResult,landingBox};


### PR DESCRIPTION
Changes from issue #652.

- Change the initial timing of the network to make sure one interaction type is always enabled.
- Remove the code to cut out the landing box when no pathway search results are found.
- Move some left over code from search to landing box.