### PR TITLE
reduce runtime in distiller services

### DIFF
--- a/src/server/enrichment-map/emap/generate-graph-info.js
+++ b/src/server/enrichment-map/emap/generate-graph-info.js
@@ -42,13 +42,11 @@ const generateGraphInfo = (pathwayInfoList, cutoff = 0.375, JCWeight, OCWeight) 
   }
 
   // check unrecognized and duplicates, modify pathwayIdList
-  const unrecognized = [];
+  const unrecognized = new Set();
   for (let pathwayId in pathwayInfoList) {
     if (!pathwayInfoList.hasOwnProperty(pathwayId)) continue;
     if (!pathwayInfoTable.has(pathwayId)) {
-      if (_.filter(unrecognized, elem => elem === pathwayId).length === 0) {
-        unrecognized.push(pathwayId);
-      }
+      unrecognized.add(pathwayId);
       delete pathwayInfoList[pathwayId];
     } else if (pathwayInfoList[pathwayId].hasOwnProperty('pathwayId')) {
       throw new Error('ERROR: additional info for ' + pathwayId + ' can not have pathwayId field');
@@ -83,7 +81,7 @@ const generateGraphInfo = (pathwayInfoList, cutoff = 0.375, JCWeight, OCWeight) 
     });
   });
 
-  return { unrecognized: unrecognized, graph: elements };
+  return { unrecognized: Array.from(unrecognized), graph: elements };
 
 };
 

--- a/src/server/enrichment-map/emap/intersect.js
+++ b/src/server/enrichment-map/emap/intersect.js
@@ -11,12 +11,16 @@ const _ = require('lodash');
 const pathwayPairGraph = (pathway1, pathway2, JCWeight) => {
   let intersectionCount = 0;
   const intersection = [];
-  _.forEach(pathway1.genes, gene => {
-    if ((pathway2.genes.filter(ele => ele === gene)).length > 0) {
+
+  const joinedPathway = pathway1.genes.concat(pathway2.genes);
+  joinedPathway.sort();
+  for (let i = 1; i < joinedPathway.length; ++i) {
+    if (joinedPathway[i] === joinedPathway[i-1]) {
       ++intersectionCount;
-      intersection.push(gene);
+      intersection.push(joinedPathway[i]);
     }
-  });
+  }
+
   // JC/OC calculation
   const pathway1Length = pathway1.genes.length;
   const pathway2Length = pathway2.genes.length;

--- a/src/server/enrichment-map/gene-validator/index.js
+++ b/src/server/enrichment-map/gene-validator/index.js
@@ -67,9 +67,10 @@ const validatorGconvert = (query, userOptions = {}) => {
         const geneInfoList = _.map(body.split('\n'), ele => { return ele.split('\t'); });
         geneInfoList.splice(-1, 1); // remove last element ''
 
-        const unrecognized = [];
-        const duplicate = {};
-        const geneInfo = [];
+        const unrecognized = new Set();
+        let duplicate = {};
+        const previous = new Set();
+        let geneInfo = new Set();
         const initialAliasIndex = 1;
         const convertedAliasIndex = 3;
         _.forEach(geneInfoList, info => {
@@ -81,25 +82,26 @@ const validatorGconvert = (query, userOptions = {}) => {
             initialAlias = initialAlias.split(':')[ncbiNameIndex];
           }
           if (convertedAlias === 'N/A') {
-            if (_.filter(unrecognized, ele => ele === initialAlias).length === 0) {
-              unrecognized.push(initialAlias);
-            }
+            unrecognized.add(initialAlias);
           } else {
-            if (_.filter(geneInfoList, ele => ele[convertedAliasIndex] === convertedAlias).length > 1) {
+            if (previous.has(convertedAlias)) {
+              previous.add(convertedAlias);
+            } else {
               if (!(convertedAlias in duplicate)) {
-                duplicate[convertedAlias] = [];
+                duplicate[convertedAlias] = new Set();
               }
-              if (_.filter(duplicate[convertedAlias], ele => ele === initialAlias).length === 0) {
-                duplicate[convertedAlias].push(initialAlias);
-              }
+              duplicate[convertedAlias].add(initialAlias);
             }
-            if (_.filter(geneInfo, ele => ele.initialAlias === initialAlias).length === 0) {
-              geneInfo.push({ initialAlias: initialAlias, convertedAlias: convertedAlias });
-            }
+            geneInfo.add(JSON.stringify({initialAlias: initialAlias, convertedAlias: convertedAlias}));
           }
         });
 
-        const ret = { unrecognized: unrecognized, duplicate: duplicate, geneInfo: geneInfo };
+        for (const initialAlias in duplicate) {
+          duplicate[initialAlias] = Array.from(duplicate[initialAlias]);
+        }
+        geneInfo = _.map(Array.from(geneInfo), ele => { return JSON.parse(ele); });
+
+        const ret = { unrecognized: Array.from(unrecognized), duplicate: duplicate, geneInfo: geneInfo };
         resolve(ret);
       })
   });


### PR DESCRIPTION
related to #635

in gene-validator/index.js and generate-graph-info.js, O(n^2)->O(n)
- use sets for unrecognized and duplicate instead of nested loops

in intersect.js, O(n^2) -> O(n)
- when counting the intersections pairwise, concatenate, sort, count consecutive duplicates