### PR TITLE
boolean number conversion, array type checking

### DIFF
--- a/src/server/enrichment/analysis/enrichment.js
+++ b/src/server/enrichment/analysis/enrichment.js
@@ -61,26 +61,34 @@ const enrichment = (query, userSetting = {}) => {
   })
 
   return promise = new Promise((resolve, reject) => {
-    let formData = _.assign({}, defaultSetting, JSON.parse(JSON.stringify(userSetting)), { query: query.join(" ") });
-    formData.custbg = formData.custbg.join(" ");
-    const orderedQueryVal = Number(formData.ordered_query);
-    const userThrVal = Number(formData.user_thr);
-    const minSetSizeVal = Number(formData.min_set_size);
-    const maxSetSizeVal = Number(formData.max_set_size);
+    let formData = _.assign({}, defaultSetting, JSON.parse(JSON.stringify(userSetting)), { query: query });
+    const queryVal = formData.query;
+    const orderedQueryVal = formData.ordered_query;
+    const userThrVal = formData.user_thr;
+    const minSetSizeVal = formData.min_set_size;
+    const maxSetSizeVal = formData.max_set_size;
     const thresholdAlgoVal = formData.threshold_algo;
+    const custbgVal = formData.custbg;
+    if (!Array.isArray(queryVal)) {
+      reject(new Error('ERROR: genes should be an array'))
+    }
+    formData.query = query.join(" ");
     if (orderedQueryVal != 0 && orderedQueryVal != 1) {
-      reject(new Error('ERROR: orderedQuery should be 1 or 0'));
+      reject(new Error('ERROR: orderedQuery should be 0 / false or 1 / true'))
     }
-    if (isNaN(userThrVal) || userThrVal > 1 || userThrVal <= 0) {
-      reject(new Error('ERROR: userThrVal should be a number in (0, 1]'));
+    if (typeof(formData.user_thr) != 'number') {
+      reject(new Error('ERROR: userThr should be a number'));
     }
-    if (isNaN(minSetSizeVal)) {
+    if (userThrVal > 1 || userThrVal <= 0) {
+      reject(new Error('ERROR: userThrVal should be in (0, 1]'));
+    }
+    if (typeof(formData.min_set_size) != 'number') {
       reject(new Error('ERROR: minSetSize should be a number'));
     }
     if (minSetSizeVal < 0) {
       reject(new Error('ERROR: minSetSize should be >= 0'));
     }
-    if (isNaN(maxSetSizeVal)) {
+    if (typeof(formData.max_set_size) != 'number') {
       reject(new Error('ERROR: maxSetSize should be a number'));
     }
     if (maxSetSizeVal < minSetSizeVal) {
@@ -89,6 +97,11 @@ const enrichment = (query, userSetting = {}) => {
     if (thresholdAlgoVal != 'analytical' && thresholdAlgoVal != 'bonferroni' && thresholdAlgoVal != 'fdr') {
       reject(new Error('ERROR: thresholdAlgoVal should be one of analytical, bonferroni, fdr'));
     }
+    if (!Array.isArray(custbgVal)) {
+      reject(new Error('ERROR: custbg should be an array'));
+    }
+    formData.custbg = custbgVal.join(" ");
+
 
     fetch(gProfilerURL, {
       method: 'post',

--- a/src/server/enrichment/validation/index.js
+++ b/src/server/enrichment/validation/index.js
@@ -39,13 +39,18 @@ const convertGConvertNames = (gConvertName) => {
   return gConvertName;
 };
 
-const validatorGconvert = (query, userOptions = {}) => {
+const validatorGconvert = (query, userOptions) => {
   return promise = new Promise((resolve, reject) => {
-    const formData = _.assign({}, defaultOptions, JSON.parse(JSON.stringify(userOptions)), { query: query.join(" ") });
+    const formData = _.assign({}, defaultOptions, JSON.parse(JSON.stringify(userOptions)), { query: query });
     formData.organism = formData.organism.toLowerCase();
     const initialTarget = formData.target.toUpperCase();
     formData.target = convertGConvertNames(initialTarget);
     const invalidInfo = { invalidTarget: undefined, invalidOrganism: undefined };
+    const queryVal = formData.query;
+    if (!Array.isArray(queryVal)) {
+      reject(new Error('ERROR: genes should be an array'));
+    }
+    formData.query = queryVal.join(" ");
     if (!validOrganism.includes(formData.organism)) {
       invalidInfo.invalidOrganism = formData.organism;
     }
@@ -101,4 +106,4 @@ const validatorGconvert = (query, userOptions = {}) => {
 };
 
 
-module.exports = { validatorGconvert };
+module.exports = { validatorGconvert, InvalidInfoError };

--- a/src/server/enrichment/visualization/generate-graph-info.js
+++ b/src/server/enrichment/visualization/generate-graph-info.js
@@ -18,8 +18,12 @@ const _ = require('lodash');
 
 // pathwayInfoList: {"GO:1":{pValue: 1}, "GO:2": {pValue: 0, color: "green"}}
 const generateGraphInfo = (pathwayInfoList, cutoff = 0.375, JCWeight, OCWeight) => {
-  if (cutoff < 0 || cutoff > 1) { throw new Error('ERROR: cutoff out of range [0, 1]'); }
-  if (isNaN(Number(cutoff))) { throw new Error('ERROR: cutoff is not a number'); }
+  if (cutoff < 0 || cutoff > 1) {
+    throw new Error('ERROR: cutoff out of range [0, 1]');
+  }
+  if (typeof(cutoff) != 'number') {
+    throw new Error('ERROR: cutoff is not a number');
+  }
 
   if (JCWeight < 0 || JCWeight > 1) {
     throw new Error('ERROR: JCWeight out of range [0, 1]');
@@ -27,9 +31,13 @@ const generateGraphInfo = (pathwayInfoList, cutoff = 0.375, JCWeight, OCWeight) 
   if (OCWeight < 0 || OCWeight > 1) {
     throw new Error('ERROR: OCWeight out of range [0, 1]');
   }
-  if (JCWeight != undefined && isNaN(Number(JCWeight))) { throw new Error('ERROR: JCWeight should be a number'); }
-  if (OCWeight != undefined && isNaN(Number(OCWeight))) { throw new Error('ERROR: OCWeight should be a number'); }
-  if (OCWeight != undefined && JCWeight != undefined && Number(OCWeight) + Number(JCWeight) != 1) {
+  if (JCWeight != undefined && typeof(JCWeight) != 'number') {
+    throw new Error('ERROR: JCWeight should be a number');
+  }
+  if (OCWeight != undefined && typeof(OCWeight) != 'number') {
+    throw new Error('ERROR: OCWeight should be a number');
+  }
+  if (OCWeight != undefined && JCWeight != undefined && OCWeight + JCWeight != 1) {
     throw new Error('ERROR: OCWeight + JCWeight should be 1');
   }
   if (JCWeight === undefined && OCWeight === undefined) {

--- a/src/server/enrichment/visualization/generate-graph-info.js
+++ b/src/server/enrichment/visualization/generate-graph-info.js
@@ -56,8 +56,6 @@ const generateGraphInfo = (pathwayInfoList, cutoff = 0.375, JCWeight, OCWeight) 
     if (!pathwayInfoTable.has(pathwayId)) {
       unrecognized.add(pathwayId);
       delete pathwayInfoList[pathwayId];
-    } else if (pathwayInfoList[pathwayId].hasOwnProperty('pathwayId')) {
-      throw new Error('ERROR: additional info for ' + pathwayId + ' can not have pathwayId field');
     }
   }
   const pathwayIdList = [];

--- a/src/server/routes/enrichment-rest.js
+++ b/src/server/routes/enrichment-rest.js
@@ -12,8 +12,7 @@ var swaggerDefinition = {
   info: {
     title: 'Enrichment Services',
     version: '1.0.0',
-    description: 'This is a sample enrichment service server. You can find detailed documentation at [Wiki](https://github.com/PathwayCommons/app-ui/wiki/Enrichment-Map-Services)',
-    documentation: "https://github.com/PathwayCommons/app-ui/wiki/Enrichment-Services",
+    description: 'This is a sample enrichment service server. You can find detailed documentation at [Wiki](https://github.com/PathwayCommons/app-ui/wiki/Enrichment-Services)',
     license: {
       name: "MIT",
       url: "https://github.com/PathwayCommons/app-ui/blob/master/LICENSE"
@@ -101,10 +100,15 @@ enrichmentRouter.post('/validation', (req, res) => {
   tmpOptions.target = req.body.target;
   validatorGconvert(genes, tmpOptions).then(gconvertResult => {
     res.json(gconvertResult);
-  }).catch((invalidInfoError) => {
-    res.status(400).send({ invalidTarget: invalidInfoError.invalidTarget, invalidOrganism: invalidInfoError.invalidOrganism });
-  });
+  }).catch((err) => {
+    if (err.constructor.name === 'InvalidInfoError') {
+      res.status(400).send({ invalidTarget: err.invalidTarget, invalidOrganism: err.invalidOrganism })
+    } else {
+      res.status(400).send(err.message);
+    }
+  })
 });
+
 
 /**
  *@swagger
@@ -217,7 +221,7 @@ enrichmentRouter.post('/visualization', (req, res) => {
  *           example: hsapiensss
  *     analysisError:
  *       type: string
- *       example: 'ERROR: orderedQuery should be 1 or 0'
+ *       example: 'ERROR: orderedQuery should be 0 / false or 1 / true'
  *     visualizationError:
  *       type: string
  *       example: 'ERROR: OCWeight + JCWeight should be 1'


### PR DESCRIPTION
- check array type for parameter 'genes' in validation and analysis services, related to #544 
- check number type explicitly, boolean to number conversion is not allowed, related to #716
- allow 1 for true, 0 for false, no other number to boolean conversion is allowed, related to #716
- delete useless code, no need to check for "pathwayId" field in visualization service input