### PR TITLE
Database labels 

### DIFF
--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -74,7 +74,7 @@ class Interactions extends React.Component {
       source.replace(/\//g,' ')
     );
     Promise.all(geneIds).then(geneIds=>{
-      ServerAPI.geneQuery({genes:geneIds.join(' '),target: 'NCBIGENE'}).then(result=>{
+      ServerAPI.geneQuery({genes:geneIds,target: 'NCBIGENE'}).then(result=>{
         const ncbiIds=result.geneInfo.map(gene=> gene.convertedAlias);
         ServerAPI.getGeneInformation(ncbiIds).then(result=>{
           const geneResults=result.result;

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -29,21 +29,22 @@ const ServerAPI = {
   },
 
   geneQuery(query){
-    const paddingAdded = _.max([2-query.genes.length,0]);
-    console.log(paddingAdded);
-    const padding = _.times(paddingAdded,()=>'p');
-    console.log(padding);
-    query.genes=_.concat(padding,query.genes);
-    
-    console.log(query.genes);
-    return fetch('/api/validation', {
-      method:'POST', 
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      body:qs.stringify(query)
-    }).then(res => res.json()).then(ids=> _.assign(ids,{unrecognized:_.drop(ids.unrecognized,paddingAdded)}));//remove padding
+    if(query.genes.length>=1){
+      const paddingAdded = _.max([2-query.genes.length,0]);
+      const padding = _.times(paddingAdded,()=>'p');
+      query.genes=_.concat(padding,query.genes);
+      return fetch('/api/validation', {
+        method:'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body:qs.stringify(query)
+      }).then(res => res.json()).then(ids=> _.assign(ids,{unrecognized:_.drop(ids.unrecognized,paddingAdded)}));//remove padding
+    }
+    else{
+      return Promise.resolve({geneInfo:[],unrecognized:[]});
+    }
   },
 
   getGeneInformation(ids){

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -29,7 +29,13 @@ const ServerAPI = {
   },
 
   geneQuery(query){
-    query.genes=_.concat(['padding'],query.genes.split(' '));
+    const paddingAdded = _.max([2-query.genes.length,0]);
+    console.log(paddingAdded);
+    const padding = _.times(paddingAdded,()=>'p');
+    console.log(padding);
+    query.genes=_.concat(padding,query.genes);
+    
+    console.log(query.genes);
     return fetch('/api/validation', {
       method:'POST', 
       headers: {
@@ -37,7 +43,7 @@ const ServerAPI = {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       body:qs.stringify(query)
-    }).then(res => res.json()).then(ids=> _.assign(ids,{unrecognized:_.tail(ids.unrecognized)}));//remove padding
+    }).then(res => res.json()).then(ids=> _.assign(ids,{unrecognized:_.drop(ids.unrecognized,paddingAdded)}));//remove padding
   },
 
   getGeneInformation(ids){

--- a/src/server/pathway-commons/search/index.js
+++ b/src/server/pathway-commons/search/index.js
@@ -10,7 +10,7 @@ const sanitize = (s) => {
 };
 
 const processPhrase = (phrase) => {
-  return geneValidator(phrase.split(' ')).then(result => {
+  return geneValidator(phrase.split(' '),{}).then(result => {
     const genes = result.geneInfo.map(gene=>'xrefid:' + sanitize(gene.initialAlias.toUpperCase()));
     const otherIds = result.unrecognized.map(id=>{
       id=id.toUpperCase()


### PR DESCRIPTION
Implementation from issue #702  
The logic for the landing box is now:
check for tokens with a database label -> pull out the uniport ones and label the rest as being an id -> id lookup on on all the genes not pulled out -> if an id was not caught and it was labeled try looking it up using PC . 
Search strips out the labels before being sent server side. 