### PR TITLE
Address issue #687 - renamed "Tools" to "Datasource"

### DIFF
--- a/src/client/common/components/base-network-view/base-network-view.js
+++ b/src/client/common/components/base-network-view/base-network-view.js
@@ -52,7 +52,7 @@ class BaseNetworkView extends React.Component {
   componentWillUnmount() {
     this.state.cy.destroy();
   }
-  
+
   componentDidMount() {
     const state = this.state;
     const initialLayoutOpts = state.layoutConfig.defaultLayout.options;
@@ -158,17 +158,13 @@ class BaseNetworkView extends React.Component {
         key: 'search',
         active: this.state.searchOpen,
         onClick: () => {
-          !this.state.searchOpen || this.clearSearchBox();
-          this.setState({ searchOpen: !this.state.searchOpen }, () => {
-            if (this.state.searchOpen == true) {
-              this.searchField.focus();
-            }
-          });
+          this.clearSearchBox();
+          this.setState({ searchOpen: !this.state.searchOpen});
         },
         desc: 'Search entities'
       }),
       h('div', {
-        className: classNames('search-nodes', { 'search-nodes-open': this.state.searchOpen }),
+        className: classNames('search-nodes'),
         onChange: e => {
           this.setState({
             nodeSearchValue: e.target.value

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -33,7 +33,7 @@ class Search extends React.Component {
       showFilters: false,
       dataSources: []
     };
-    
+
       ServerAPI.datasources()
         .then(result => {
           this.setState({
@@ -209,7 +209,7 @@ class Search extends React.Component {
                   className: classNames('search-option-item', 'search-option-item-tools', { 'search-option-item-tools-active': state.showFilters }),
                   onClick: e => this.setState({ showFilters: !state.showFilters })
                 }, [
-                    h('a', 'Tools')
+                    h('a', 'Datasource')
                   ])
               ]))
             ])
@@ -218,7 +218,7 @@ class Search extends React.Component {
       h(Loader, { loaded: loaded, options: { left: '50%', color: '#16A085' } }, [
         h('div.search-list-container', [
           h('div.search-result-info', [searchResultInfo]),
-          h(landingBox,{controller,landing}), 
+          h(landingBox,{controller,landing}),
           h('div.search-list', searchResults)
         ])
       ])

--- a/src/styles/features/search.css
+++ b/src/styles/features/search.css
@@ -138,7 +138,7 @@
 }
 
 .search-option-item-tools {
-  margin-left: '50px';
+  margin-left: auto;
 }
 
 .search-option-item-tools-active {

--- a/src/styles/features/search.css
+++ b/src/styles/features/search.css
@@ -119,7 +119,7 @@
 .search-option-item-container {
   margin-right: 10px;
   cursor: pointer;
-  
+
   transition: all 0.1s linear;
 }
 
@@ -138,7 +138,7 @@
 }
 
 .search-option-item-tools {
-  margin-left: auto;
+  margin-left: '50px';
 }
 
 .search-option-item-tools-active {
@@ -287,7 +287,7 @@
   font-weight: lighter;
   text-decoration: underline;
   font-style: italic;
-  white-space: pre; 
+  white-space: pre;
   padding-right: 5px;
   display: inline-flex;
   cursor: pointer;
@@ -305,7 +305,7 @@
   justify-content: center;
 }
 .search-landing-button:hover {
-  background-color: #6E9ABD; 
+  background-color: #6E9ABD;
   color: white;
 }
 
@@ -316,7 +316,7 @@
 
 .search-item {
   display: flex;
-  vertical-align: middle; 
+  vertical-align: middle;
   align-items: center;
   padding-top: 20px;
   padding-bottom: 20px;

--- a/src/styles/features/view/menuBar.css
+++ b/src/styles/features/view/menuBar.css
@@ -111,31 +111,15 @@ _::-webkit-full-page-media, _:future, :root .view-toolbar{
 }
 
 .search-nodes {
-  @extend %flex-center;
-  @extend %no-select;
-
-  height: calc(var(--icon-size) * 3 / 2);
-  width: 0;
-  padding: 0;
-
-  box-sizing: border-box;
-  overflow: hidden;
-
+  width: 11em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  overflow: visible;
   font-size: 0.9em;
-
-  transition: all 0.1s ease-out;
-
-  &.search-nodes-open {
-    width: 11em;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
-    overflow: visible;
-  }
+  box-sizing: border-box;
 }
 
 .view-search-bar {
-  @extend %flex-center;
-
   height: 1.85em;
   width: 100%;
   background-color: white;


### PR DESCRIPTION
Altered src/client/features/search/index.js by renaming the "Tools" button found on the pathway search page to read "Datasource" 
***** This commit accidentally contains changes to search.css 

Before:
![image](https://user-images.githubusercontent.com/38890251/39818803-bd295bfc-536f-11e8-87db-3f42b9b4d222.png)

After:
![image](https://user-images.githubusercontent.com/38890251/39818823-d0c41530-536f-11e8-82b7-1c66912b1aed.png)


