### PR TITLE
Modified Tooltip Links to Pathway Commons Search

### DIFF
--- a/src/client/common/cy/tooltips/format-content.js
+++ b/src/client/common/cy/tooltips/format-content.js
@@ -76,6 +76,14 @@ const defaultHandler = (pair) => {
   ]);
 };
 
+//Handle PC Search Related Fields
+const searchLinkHandler = (pair) => {
+  let searchTerm = pair[1];
+  return h('div.fake-paragraph',
+  h('a.tooltip-search-link',{href:"/search?q=" + searchTerm,target:"_blank"},'Search Pathway Commons for "' + searchTerm + '"')
+  );
+};
+
 const metaDataKeyMap = new Map()
   .set('Standard Name', standardNameHandler)
   .set('Display Name', displayNameHandler)
@@ -84,7 +92,8 @@ const metaDataKeyMap = new Map()
   .set('Database IDs', databaseHandler)
   .set('Publications', publicationHandler)
   .set('List',listHandler)
-  .set('Detailed Views',viwerListHandler);
+  .set('Detailed Views',viwerListHandler)
+  .set('Search Link',searchLinkHandler);
 
  /**
   * parseMetadata(pair, trim)

--- a/src/client/common/cy/tooltips/index.js
+++ b/src/client/common/cy/tooltips/index.js
@@ -33,8 +33,6 @@ class MetadataTip {
     getPublications(this.data).then(function (data) {
       this.data = data;
 
-      console.log(data);
-
       //Hide all other tooltips
       this.hideAll(cy);
 

--- a/src/client/common/cy/tooltips/index.js
+++ b/src/client/common/cy/tooltips/index.js
@@ -16,7 +16,7 @@ class MetadataTip {
     this.data = data.parsedMetadata;
     //Add an extra piece of metadata for proteins
     if(data.class === "macromolecule")
-      this.data.push(["Search Link",this.name]);
+      this.data.push(["Search Link",data.label]);
     this.cyElement = cyElement;
     this.db = config.databases;
     this.viewStatus = {};

--- a/src/client/common/cy/tooltips/index.js
+++ b/src/client/common/cy/tooltips/index.js
@@ -14,6 +14,9 @@ class MetadataTip {
   constructor(name, data, cyElement) {
     this.name = name;
     this.data = data.parsedMetadata;
+    //Add an extra piece of metadata for proteins
+    if(data.class === "macromolecule")
+      this.data.push(["Search Link",this.name]);
     this.cyElement = cyElement;
     this.db = config.databases;
     this.viewStatus = {};
@@ -29,6 +32,8 @@ class MetadataTip {
 
     getPublications(this.data).then(function (data) {
       this.data = data;
+
+      console.log(data);
 
       //Hide all other tooltips
       this.hideAll(cy);
@@ -83,9 +88,7 @@ class MetadataTip {
 
     if (!(this.data)) { this.data = []; }
     return h('div.tooltip-image', [
-      h('div.tooltip-heading', [
-        h('a.tooltip-heading-link',{href:"/search?&q="+this.name,target:"_blank"},this.name),
-        ]),
+      h('div.tooltip-heading', this.name),
       h('div.tooltip-internal', h('div', (data).map(item => formatContent.parseMetadata(item, true, expandFunction, this.name)), this))
     ]);
   }
@@ -112,9 +115,7 @@ class MetadataTip {
 
     if (!(this.data)) { this.data = []; }
     return h('div.tooltip-image', [
-      h('div.tooltip-heading', [
-      h('a.tooltip-heading-link',{href:"/search?&q="+this.name,target:"_blank"},this.name),
-      ]),
+      h('div.tooltip-heading', this.name),
       h('div.tooltip-internal', h('div', (data).map(item => formatContent.parseMetadata(item, !this.isExpanded(item[0]), getExpansionFunction(item), this.name), this)))
     ]
     );

--- a/src/styles/features/view/toolTip.css
+++ b/src/styles/features/view/toolTip.css
@@ -133,8 +133,9 @@
   line-height: 1.5;
 }
 
-.tooltip-heading-link{
+.tooltip-search-link{
   text-decoration: underline;
+  font-weight:bold;
   display:inline;
   color: var(--link);
 }


### PR DESCRIPTION
Changed Location of Link in tooltip and improved link text so users know what they are clicking on.  Based on Discussion in #483 
Fixes #483 
New tooltip looks like:
![tooltip-screenshot](https://user-images.githubusercontent.com/25777239/40022907-600cb672-5797-11e8-9dcf-03cfab242b87.png)

It was going to take alot of work to have the link above the "Links" section as discussed earlier, and I think this looks almost identical.  Can change if wanted.
