### PR TITLE
Removed Plaintext Instances of pathway commons URL & URI

### DIFF
--- a/src/client/common/components/base-network-view/base-network-view.js
+++ b/src/client/common/components/base-network-view/base-network-view.js
@@ -9,6 +9,9 @@ const IconButton = require('../icon-button');
 
 const debouncedSearchNodes = _.debounce(require('../../cy/match-style'), 300);
 
+const conf = require("../../config");
+const BASE_URL = conf.BASE_URL;
+
 // cytoscape
 // grapjson
 // metadata
@@ -178,7 +181,7 @@ class BaseNetworkView extends React.Component {
       h('div', { className: classNames('menu-bar', { 'menu-bar-margin': state.activeMenu }) }, [
         h('div.menu-bar-inner-container', [
           h('div.pc-logo-container', [
-            h('a', { href: 'http://www.pathwaycommons.org/' } , [
+            h('a', { href: BASE_URL } , [
               h('img', {
                 src: '/img/icon.png'
               })

--- a/src/client/common/config.js
+++ b/src/client/common/config.js
@@ -1,3 +1,6 @@
+const conf = require("../../config");
+const PC_URI = conf.PC_URI;
+
 const databases = [
   {database:'BioGrid', url:'http://identifiers.org/biogrid/', search:''},
   {database:'DrugBank', url:'https://www.drugbank.ca/', search:''},
@@ -23,7 +26,7 @@ const databases = [
   {database:'CAS', url:'http://identifiers.org/cas/', search:''},
   {database:'HPRD',url:'http://identifiers.org/hprd/',search:''},
   {database:'RefSeq',url:'http://identifiers.org/refseq/',search:''},
-  {database:'Pathway Commons',url:'http://pathwaycommons.org/pc2/',search:''},
+  {database:'Pathway Commons',url:PC_URI,search:''},
   {database:'NCBI Gene',url:'http://identifiers.org/ncbigene/',search:''},
   {database:'Gene Cards',url:'http://identifiers.org/genecards/',search:''}
 ];

--- a/src/client/features/entry/index.js
+++ b/src/client/features/entry/index.js
@@ -4,6 +4,8 @@ const queryString = require('query-string');
 const _ = require('lodash');
 
 const Icon = require('../../common/components').Icon;
+const conf = require("../../../config");
+const BASE_URL = conf.BASE_URL;
 
 
 // requires react router props
@@ -43,7 +45,7 @@ class Entry extends React.Component {
     return h('div.entry', [
       h('div.entry-header', [
         h('a.entry-pc-link', {
-          href: 'https://www.pathwaycommons.org'
+          href: BASE_URL
         }, [
           h('i.entry-logo')
         ]),

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -10,6 +10,8 @@ const classNames = require('classnames');
 const Icon = require('../../common/components').Icon;
 const { ServerAPI } = require('../../services');
 const Landing = require('./landing-box');
+const conf = require("../../../config");
+const BASE_URL = conf.BASE_URL;
 
 class Search extends React.Component {
 
@@ -172,7 +174,7 @@ class Search extends React.Component {
         h('div.search-header', [
           h('div.search-branding', [
             h('div.search-title', [
-              h('a', { className: 'search-pc-link', href: 'http://www.pathwaycommons.org/' } , [
+              h('a', { className: 'search-pc-link', href: BASE_URL } , [
                 h('i.search-logo')
               ]),
             ]),

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -4,6 +4,9 @@ const _ = require('lodash');
 
 const socket = io.connect('/');
 
+const conf = require("../../../config");
+const PC_URI = conf.PC_URI;
+
 const defaultFetchOpts = {
   method: 'GET', headers: {
     'Content-type': 'application/json',
@@ -51,7 +54,7 @@ const ServerAPI = {
   getNeighborhood(ids,kind){
    const source=ids.map(id=>`source=${id}`).join('&');
    const patterns = '&pattern=controls-phosphorylation-of&pattern=in-complex-with&pattern=controls-expression-of&pattern=interacts-with';
-    return fetch(`http://www.pathwaycommons.org/pc2/graph?${source}&kind=${kind}&format=TXT${patterns}`,defaultFetchOpts).then(res => res.text());
+    return fetch(PC_URI + `graph?${source}&kind=${kind}&format=TXT${patterns}`,defaultFetchOpts).then(res => res.text());
   },
 
   // Send a diff in a node to the backend. The backend will deal with merging these diffs into

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,8 @@ const _ = require('lodash');
 
 let defaults = {
   PORT: 3000,
-  MASTER_PASSWORD: ''
+  PC_URI: "https://www.pathwaycommons.org/pc2/",
+  BASE_URL: "https://www.pathwaycommons.org"
 };
 
 let envVars = _.pick( process.env, Object.keys( defaults ) );

--- a/src/server/graph-generation/generic-physical-entities/index.js
+++ b/src/server/graph-generation/generic-physical-entities/index.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 const fs = require('fs');
+const conf = require("../../../config");
+const PC_URI = conf.PC_URI;
 
 const getGenericPhysicalEntityMap = _.memoize(() => JSON.parse(fs.readFileSync(__dirname + '/generic-physical-entity-map.json', 'utf-8')));
 
@@ -8,7 +10,7 @@ const getNodesGeneSynonyms = nodes => {
   const genericPhysicalEntityMap = getGenericPhysicalEntityMap();
 
   nodes.forEach(node => {
-    const lookupId = 'http://pathwaycommons.org/pc2/' + node.data.id;
+    const lookupId = PC_URI + node.data.id;
     nodeGeneSynonyms[node.data.id] = _.get(genericPhysicalEntityMap[lookupId], 'synonyms', []);
   });
 

--- a/src/server/pathway-commons/index.js
+++ b/src/server/pathway-commons/index.js
@@ -5,7 +5,8 @@ const fetch = require('node-fetch');
 
 const search = require('./search/');
 const datasources = require('./datasources');
-
+const conf = require("../../config");
+const PC_URI = conf.PC_URI;
 
 const fetchOptions = {
   method: 'GET',
@@ -14,6 +15,7 @@ const fetchOptions = {
     'Accept': 'application/json'
   }
 };
+
 
 const PathwayCommonsService = {
   // query pathway commons for pathways, sbgn, information, etc.
@@ -44,7 +46,7 @@ const PathwayCommonsService = {
 
   get(options) {
     //Construct query url
-    let url = 'https://www.pathwaycommons.org/pc2/get?' + qs.stringify(options);
+    let url = PC_URI + 'get?' + qs.stringify(options);
     return fetch(url, fetchOptions).then(response => response.text());
   },
 
@@ -53,25 +55,25 @@ const PathwayCommonsService = {
   //Requires a valid query and uri
   traverse(options) {
     //Construct query url
-    let url = 'https://www.pathwaycommons.org/pc2/traverse?' + qs.stringify(options);
+    let url = PC_URI + 'traverse?' + qs.stringify(options);
     return fetch(url, fetchOptions).then(response => response.json());
   },
 
   search(options) {
     //Construct query url
-    let url = 'https://www.pathwaycommons.org/pc2/search?' + qs.stringify(options);
+    let url = PC_URI + 'search?' + qs.stringify(options);
     return fetch(url, fetchOptions).then(response => response.json());
   },
 
   graph(options) {
     //Construct query url
-    let url = 'https://www.pathwaycommons.org/pc2/graph?' + qs.stringify(options);
+    let url = PC_URI + 'graph?' + qs.stringify(options);
     return fetch(url, fetchOptions).then(response => response.json());
   },
 
   top_pathways(options) {
     //Construct query url
-    let url = 'https://www.pathwaycommons.org/pc2/top_pathways?' + qs.stringify(options);
+    let url = PC_URI + 'top_pathways?' + qs.stringify(options);
     return fetch(url, fetchOptions).then(response => response.json());
   }
 };

--- a/src/server/routes/pc.js
+++ b/src/server/routes/pc.js
@@ -3,6 +3,8 @@ const express = require('express');
 const qs = require('querystring');
 const pc = require('../pathway-commons/');
 const router = express.Router();
+const conf = require("../../config");
+const PC_URI = conf.PC_URI;
 
 router.get('/datasources', function (req, res) {
   pc.datasources().then(r => res.json(r));
@@ -13,7 +15,7 @@ router.get('/querySearch', function (req, res) {
 });
 
 router.get('/:path', function (req, res) {
-  res.redirect('http://www.pathwaycommons.org/pc2/' + req.params.path + '?' + qs.stringify(req.query));
+  res.redirect(PC_URI + req.params.path + '?' + qs.stringify(req.query));
 });
 
 module.exports = router;


### PR DESCRIPTION
References Issue #764 
Replaced with an environment variable, which can be easily modified in `src/config.js` by replacing the following values:
![code_image](https://user-images.githubusercontent.com/25777239/40199801-96e74f56-59e8-11e8-9125-11b7244d575c.png)


BASE_URL has now replaced instances of:
`http://www.pathwaycommons.org`
`https://www.pathwaycommons.org`
`http://pathwaycommons.org`
`https://pathwaycommons.org`

PC_URI has now replaced instances of:
`http://www.pathwaycommons.org/pc2/`
`https://www.pathwaycommons.org/pc2/`
`http://pathwaycommons.org/pc2/`
`https://pathwaycommons.org/pc2/`

There are still some instances remaining.  Specifically in the files:
`src/scripts/datasources.js`
`src/client/features/paint/demo-pathway-results.json`
`src/server/graph-generation/generic-physical-entities/generic-physical-entity-map.json`
This is due to the volume of replacements necessary, some of these files have over 10000 instances.