### PR TITLE
Landing box pcQuery uses incorrect parameter name

### DIFF
--- a/src/client/features/search/landing-box.js
+++ b/src/client/features/search/landing-box.js
@@ -31,7 +31,7 @@ const linkBuilder= (source,geneQuery)=>{
 const pcFallback = (unrecognized,genes) => {
  return unrecognized.map(entry=>{
     if(!genes[entry]){
-     return ServerAPI.pcQuery('search', {q:entry,entry:'entityreference'}).then((search)=>{
+     return ServerAPI.pcQuery('search', {q:entry,type:'entityreference'}).then((search)=>{
         const ids = _.compact(search.searchHit.map(hit=>{
           hit =_.reverse(hit.uri.split('/'));
           return hit[1]==='uniprot' ? hit[0] : false;

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -31,7 +31,7 @@ const ServerAPI = {
   geneQuery(query){
     query.genes=_.concat(['padding'],query.genes.split(' '));
     return fetch('/api/validation', {
-      method:'POST', 
+      method:'POST',
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/x-www-form-urlencoded'


### PR DESCRIPTION
ref #768 
Before:
`ServerAPI.pcQuery('search', {q:entry,entry:'entityreference'})`

After:
`ServerAPI.pcQuery('search', {q:entry,type:'entityreference'})`

