### PR TITLE
Correct content-type in geneQuery

### DIFF
--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -34,9 +34,9 @@ const ServerAPI = {
       method:'POST',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
+        'Content-Type': 'application/json'
       },
-      body:qs.stringify(query)
+      body:JSON.stringify(query)
     }).then(res => res.json()).then(ids=> _.assign(ids,{unrecognized:_.tail(ids.unrecognized)}));//remove padding
   },
 


### PR DESCRIPTION
Content type is changed to `application/json`
Request body is changed to JSON format.

ref: #767 