### PR TITLE
Remove call to pcFallback

### DIFF
--- a/src/client/features/search/landing-box.js
+++ b/src/client/features/search/landing-box.js
@@ -131,7 +131,7 @@ const getLandingResult= (query)=> {
     let genes=values[0];
     _.tail(values).forEach(gene=>_.mergeWith(genes,gene,(objValue, srcValue)=>_.assign(objValue,srcValue)));
     return genes;
-  }).then(genes=>Promise.all(pcFallback(genes.unrecognized,genes)).then(()=>genes)).then((genes)=>{
+  }).then(genes=>{
       let ncbiIds={},uniprotIds={};
       _.forEach(genes,(gene,search)=>{
         if(gene['NCBI Gene']){


### PR DESCRIPTION
Ref:#770

`pcFallback` is returning garbage landing box. The call is removed from `getLandingResult`