### PR TITLE
Modified Interaction tooltips to display PubMed citation info

### DIFF
--- a/src/client/common/cy/tooltips/publications.js
+++ b/src/client/common/cy/tooltips/publications.js
@@ -88,8 +88,6 @@ function getPublications(data) {
     }
   }
 
-  console.log(data);
-
   return new Promise(function (resolve, reject) {
     if (!(data)) { resolve(data); }
 

--- a/src/client/common/cy/tooltips/publications.js
+++ b/src/client/common/cy/tooltips/publications.js
@@ -53,6 +53,43 @@ function processPublicationData(data) {
  */
 function getPublications(data) {
 
+  /*
+  Sometimes the PubMed citation info gets loaded in as an element in the "List" part of the "data" array.
+  It should be in the "Database IDs" section.
+  This mess properly adds the citation info into "Database IDs", and removes the citation info from "List".
+  */
+  for(let i in data){
+    if(data[i][0] === "List"){
+      for(let j in data[i][1]){
+        if(data[i][1][j][0] === "PubMed"){
+          //Is there already an element in 'data' which contains database info?
+          //if so add the new citation to that list
+          let databaseAlreadyStored = false;
+          for(let k in data){
+            if(data[k][0] === 'Database IDs'){
+              data[k][1].push(["pubmed",data[i][1][j][1]]);
+              databaseAlreadyStored = true;
+              break;
+            }
+          }
+          //otherwise create the list and add citation to it
+          if(!databaseAlreadyStored)
+            data.push([["Database IDs"], [["pubmed",data[i][1][j][1]]]]);
+          
+
+          //remove 'PubMed' from list
+          data[i][1].splice(j,1);
+          //Remove 'list' from data if there's nothing left
+          if(data[i][1].length < 1){
+            data.splice(i,1);
+          }
+        }
+      }
+    }
+  }
+
+  console.log(data);
+
   return new Promise(function (resolve, reject) {
     if (!(data)) { resolve(data); }
 


### PR DESCRIPTION
References #620 
It appears that when generating tooltips, the citation data is being passed differently in `View` vs `Interactions`.
`Interactions` Example:
![s](https://user-images.githubusercontent.com/25777239/40374287-c11aeaea-5db6-11e8-9ccd-c34c08521558.png)
`View` Example:
![screen shot 2018-05-22 at 11 52 59 am](https://user-images.githubusercontent.com/25777239/40374352-e1a3202a-5db6-11e8-887e-6d1d9eaa961a.png)
![screen shot 2018-05-22 at 11 53 03 am](https://user-images.githubusercontent.com/25777239/40374361-e520e732-5db6-11e8-813f-3a1376099608.png)

I changed the tooltip generation to include a check to ensure if any citation info is being passed through `"List"` to move it to `"Database IDs"`.

Old `Interaction` Tooltip:
![s](https://user-images.githubusercontent.com/25777239/40375321-3f734c78-5db9-11e8-9ed0-1359d97d5a97.png)

New `Interaction` Tooltip:
![s](https://user-images.githubusercontent.com/25777239/40375384-6be83606-5db9-11e8-9de9-b8de0504fd8b.png)
