### PR TITLE
Remove unused value from geneQuery

### DIFF
--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -29,7 +29,7 @@ const ServerAPI = {
   },
 
   geneQuery(query){
-    query.genes=_.concat(['padding'],query.genes.split(' '));
+    query.genes=query.genes.split(' ');
     return fetch('/api/validation', {
       method:'POST',
       headers: {


### PR DESCRIPTION
Ref: #767 
`padding` in the query function is unused after the content-type is changed to `application/json`