### PR TITLE
Text input field allows multiple tokens

### DIFF
--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -26,7 +26,7 @@ const ServerAPI = {
 
   querySearch(query){
     const queryClone=_.assign({},query);
-    queryClone.q=queryClone.q.replace(/(uniprot|ncbi|hgnc)\s*:/gi,"").replace(/\s\s+/g, ' ').replace(/\s+$/, '');
+    queryClone.q=queryClone.q.replace(/^(uniprot|ncbi|hgnc):/i,"");
     return fetch(`/pc-client/querySearch?${qs.stringify(queryClone)}`, defaultFetchOpts).then(res => res.json());
   },
 

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -26,7 +26,9 @@ const ServerAPI = {
 
   querySearch(query){
     const queryClone=_.assign({},query);
-    queryClone.q=queryClone.q.replace(/^(uniprot|ncbi|hgnc):/i,"");
+    if (/^((uniprot|hgnc):\w+|ncbi:[0-9]+)$/i.test(queryClone.q)) {
+      queryClone.q=queryClone.q.replace(/^(uniprot|ncbi|hgnc):/i,"");
+    }
     return fetch(`/pc-client/querySearch?${qs.stringify(queryClone)}`, defaultFetchOpts).then(res => res.json());
   },
 

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -26,7 +26,7 @@ const ServerAPI = {
 
   querySearch(query){
     const queryClone=_.assign({},query);
-    if(/(uniprot:\w+|ncbi:[0-9]+|hgnc:\w+)$/.test(queryClone.q)){queryClone.q=queryClone.q.split(':')[1];}
+    queryClone.q=queryClone.q.replace(/(uniprot|ncbi|hgnc)\s*:/gi,"").replace(/\s\s+/g, ' ').replace(/\s+$/, '');
     return fetch(`/pc-client/querySearch?${qs.stringify(queryClone)}`, defaultFetchOpts).then(res => res.json());
   },
 


### PR DESCRIPTION
Text input field accepts multiple tokens of the form `db:id` (ref:#790):
<br/>
![screen shot 2018-05-30 at 10 47 34 am](https://user-images.githubusercontent.com/16858225/40728024-34d5921e-63f7-11e8-986a-c63c796aefa5.png)
<br/>
The procedure is:

1. Remove all prefix db:id in input string
2. Remove extra spaces
3. Search ids as before.