### PR TITLE
Added fix for empty network view

### DIFF
--- a/src/client/features/view/index.js
+++ b/src/client/features/view/index.js
@@ -65,9 +65,18 @@ class View extends React.Component {
       networkJSON: state.networkJSON,
       networkMetadata: state.networkMetadata
     });
+    
+    //If the network is empty, display an error message
+    if(Object.keys(state.networkJSON).length !== 0 && state.networkJSON.edges.length < 1 && state.networkJSON.nodes.length < 1){
+      return h("div.emptyNetwork",{style:{textAlign:"center"}},[
+        h("img",{src:"/img/icon.png",style:{height:"auto",width:"5%",padding:"20px 0px 0px 0px"}}),
+        h('h1',state.networkMetadata.name + " from " + state.networkMetadata.datasource + " is an empty network"),
+        h("a",{href:"http://apps.pathwaycommons.org",style:{color:"blue"}},"Return to PC Home")
+      ]);
+    }
 
     const loadingView = h(Loader, { loaded: !state.loading, options: { left: '50%', color: '#16A085' }});
-
+    
     // create a view shell loading view e.g looks like the view but its not
     const content = state.loading ? loadingView : baseView;
 


### PR DESCRIPTION
Refs #779 .
When pathway commons attempts to load a network with no nodes or edges, the following message will be displayed:

![screen shot 2018-06-01 at 10 36 59 am](https://user-images.githubusercontent.com/25777239/40846480-ba15e910-6587-11e8-941e-83aa273fb9dc.png)
