### PR TITLE
Fixed Error with tooltip Display

### DIFF
--- a/src/client/common/components/base-network-view/config/index.js
+++ b/src/client/common/components/base-network-view/config/index.js
@@ -21,6 +21,11 @@ const resetToDefaultLayout = (props) => {
   cy.layout(props.layoutConfig.defaultLayout.options).run();
 };
 
+const onlyShowSelected = (props) => {
+  const cy = props.cy;
+  console.log(cy.userSelectedElements);
+};
+
 
 // material icon name to func/description object
 const toolbarButtons = [
@@ -58,6 +63,14 @@ const toolbarButtons = [
     type: 'networkAction',
     func: resetToDefaultLayout,
     description: 'Reset network arrangement'
+  },
+  {
+    id:'onlyShowSelected',
+    icon:'replay',
+    type:'networkAction',
+    func:onlyShowSelected,
+    description:'Only Show selected nodes',
+
   }
 ];
 

--- a/src/client/common/components/base-network-view/config/index.js
+++ b/src/client/common/components/base-network-view/config/index.js
@@ -57,8 +57,8 @@ const onlyShowSelected = (props) => {
   }
 
   //loop through the selected nodes, when a match has been found in the graph
-  //show that node and all it's children
-  
+  //show that entity and all it's children
+
   //TODO show partners if an interaction is selected
   for(let i in userSelectedElements){
     let userNode = userSelectedElements[i];
@@ -75,6 +75,7 @@ const onlyShowSelected = (props) => {
   }
 };
 
+//helper function to show children of an entity
 const showAllChildren = (node) => {
   if(node.children){
     const nodeChildren = node.children();

--- a/src/client/common/components/base-network-view/config/index.js
+++ b/src/client/common/components/base-network-view/config/index.js
@@ -21,9 +21,68 @@ const resetToDefaultLayout = (props) => {
   cy.layout(props.layoutConfig.defaultLayout.options).run();
 };
 
+/**
+ * @description Hides all nodes that the user has selected
+ */
+const hideSelected = (props) => {
+  const cy = props.cy;
+  const nodeList = cy.nodes();
+  const userSelectedElements = cy.userSelectedElements;
+
+  //loop through all nodes in graph
+  //if a match is found in the user-selected nodes, hide it
+  for(let i in nodeList){
+    let node = nodeList[i];
+    if(!node.data)
+      continue;
+    if(userSelectedElements.includes(node.data()))
+      node.hide();
+  }
+};
+
+/**
+ * @description Hides all nodes that the user has NOT selected
+ */
 const onlyShowSelected = (props) => {
   const cy = props.cy;
-  console.log(cy.userSelectedElements);
+  const nodeList = cy.nodes();
+  const userSelectedElements = cy.userSelectedElements;
+
+  //First, hide every node in the graph
+  for(let i in nodeList){
+    let node = nodeList[i];
+    if(!node.data)
+      continue;
+    node.hide();
+  }
+
+  //loop through the selected nodes, when a match has been found in the graph
+  //show that node and all it's children
+  
+  //TODO show partners if an interaction is selected
+  for(let i in userSelectedElements){
+    let userNode = userSelectedElements[i];
+    for(let j in nodeList){
+      let node = nodeList[j];
+      if(!node.data)
+        continue;
+      if(userNode === node.data()){
+        node.show();
+        node.parents().show();
+        showAllChildren(node);
+      }
+    }
+  }
+};
+
+const showAllChildren = (node) => {
+  if(node.children){
+    const nodeChildren = node.children();
+    nodeChildren.show();
+    for(let x in nodeChildren){
+      showAllChildren(nodeChildren[x]);
+    }
+  }
 };
 
 
@@ -65,11 +124,19 @@ const toolbarButtons = [
     description: 'Reset network arrangement'
   },
   {
+    id:'hideSelected',
+    icon:'replay',
+    type:'networkAction',
+    func:hideSelected,
+    description:'Hide Selected Nodes',
+
+  },
+  {
     id:'onlyShowSelected',
     icon:'replay',
     type:'networkAction',
     func:onlyShowSelected,
-    description:'Only Show selected nodes',
+    description:'Only Show Selected Nodex',
 
   }
 ];

--- a/src/client/common/cy/events/click.js
+++ b/src/client/common/cy/events/click.js
@@ -10,11 +10,22 @@ const hideTooltips = (cy) => {
   });
 };
 
+const userSelectedElements = [];
+
 const bindClick = (cy) => {
 
   cy.on('tap', evt => {
     const cy = evt.cy;
     const ele = evt.target;
+
+    if(ele.data){
+      const data = ele.data();
+      if(data && userSelectedElements.indexOf(data) === -1){
+        userSelectedElements.push(ele.data());
+      }
+    }
+
+    cy.userSelectedElements = userSelectedElements;
 
     if (!ele.scratch('_tooltip-opened')) {
       hideTooltips(cy);	

--- a/src/client/common/cy/events/click.js
+++ b/src/client/common/cy/events/click.js
@@ -18,11 +18,12 @@ const bindClick = (cy) => {
     const cy = evt.cy;
     const ele = evt.target;
 
+
+
     if(ele.data){
       const data = ele.data();
-      if(data && userSelectedElements.indexOf(data) === -1){
-        userSelectedElements.push(ele.data());
-      }
+      if(data && data.class !== "interaction" && userSelectedElements.indexOf(data) === -1)
+        userSelectedElements.push(ele.data()); 
     }
 
     cy.userSelectedElements = userSelectedElements;

--- a/src/client/common/cy/tooltips/index.js
+++ b/src/client/common/cy/tooltips/index.js
@@ -21,9 +21,8 @@ class MetadataTip {
           if(this.data[i][0]==="Display Name")
             this.data.push(["Search Link",this.data[i][1]]);
         }
-      }else{
+      }else if(this.data)
         this.data.push(["Search Link",this.name]);
-      }
     this.cyElement = cyElement;
     this.db = config.databases;
     this.viewStatus = {};

--- a/src/client/common/cy/tooltips/publications.js
+++ b/src/client/common/cy/tooltips/publications.js
@@ -77,7 +77,8 @@ function getPublications(data) {
     }
   }
 
-  data.push([["Database IDs"],databaseInfo]);
+  if(data && databaseInfo !== [])
+    data.push([["Database IDs"],databaseInfo]);
 
   return new Promise(function (resolve, reject) {
     if (!(data)) { resolve(data); }


### PR DESCRIPTION
Some pid pathways have entities with `null` data array.  This was causing the tooltip display to throw an error in console.  This PR fixes some errors being thrown as code assumed data array was `[]` not `null`