### PR TITLE
Fixed Error with tooltip Display

### DIFF
--- a/src/client/common/cy/tooltips/format-content.js
+++ b/src/client/common/cy/tooltips/format-content.js
@@ -26,7 +26,7 @@ const nameHandler = (pair, expansionFunction, trim) => {
 const databaseHandler = (pair, expansionFunction, trim) => {
   const expansionLink = h('div.more-link', { onclick: () => expansionFunction(pair[0]) }, trimString(trim));
   if (pair[1].length < 1) { return h('div.error'); }
-  return generateDatabaseList(sortByDatabaseId(pair[1]), trim, expansionLink);
+  return generateDatabaseList(sortByDatabaseId(pair[1]),expansionLink,trim);
 };
 
 //Handle interaction/Detailed views related fields

--- a/src/client/common/cy/tooltips/index.js
+++ b/src/client/common/cy/tooltips/index.js
@@ -21,7 +21,7 @@ class MetadataTip {
           if(this.data[i][0]==="Display Name")
             this.data.push(["Search Link",this.data[i][1]]);
         }
-      }else{
+      }else if(this.data){
         this.data.push(["Search Link",this.name]);
       }
     this.cyElement = cyElement;

--- a/src/client/common/cy/tooltips/publications.js
+++ b/src/client/common/cy/tooltips/publications.js
@@ -76,7 +76,7 @@ function getPublications(data) {
       data[i][1] = data[i][1].filter(checkForCitation);
     }
   }
-  if(data && databaseInfo !== [])
+  if(data && databaseInfo.length > 0)
     data.push([["Database IDs"],databaseInfo]);
 
   return new Promise(function (resolve, reject) {

--- a/src/client/common/cy/tooltips/publications.js
+++ b/src/client/common/cy/tooltips/publications.js
@@ -76,8 +76,8 @@ function getPublications(data) {
       data[i][1] = data[i][1].filter(checkForCitation);
     }
   }
-
-  data.push([["Database IDs"],databaseInfo]);
+  if(data && databaseInfo !== [])
+    data.push([["Database IDs"],databaseInfo]);
 
   return new Promise(function (resolve, reject) {
     if (!(data)) { resolve(data); }

--- a/src/server/graph-generation/biopax-metadata/index.js
+++ b/src/server/graph-generation/biopax-metadata/index.js
@@ -1,4 +1,5 @@
 const metadataParser = require('./metadataParserJson');
+const _ = require('lodash');
 var biopaxFile = null;
 /**
  * 
@@ -68,43 +69,40 @@ function buildBioPaxTree(entity) {
   let collectedData = collectEntityMetadata(entity);
 
   //Collect Data for cross-references
+  let xrefList = [];
   let xref = entity['xref'];
-  if (typeof xref == 'string')
-    xref = [xref];
-  if (!(xref))
-    xref = [];
   let eref = entity['entityReference'];
-  if (eref)
-    xref.push(eref);
+  if(xref)
+    xrefList = _.concat(xrefList,[xref]);
+  if(eref)
+    xrefList = _.concat(xrefList,[eref]);
 
-  processXrefs(xref,eref,collectedData);
+  processXrefs(xrefList,eref,collectedData);
   
   result.push([id,collectedData]);
   return result;
 }
 
-function processXrefs(xref,eref,collectedData){
+function processXrefs(xrefList,eref,collectedData){
 
-  let ErefXref = [];
+  let erefXrefList = [];
 
-  for (let i = 0; i < xref.length; i++) {
+  for (let i = 0; i < xrefList.length; i++) {
     //Check if this is a cross-reference or entity reference
     let keyName = 'Reference';
-    if (i == (xref.length - 1) && eref)
+    if (i == (xrefList.length - 1) && eref)
       keyName = 'EntityReference';
 
     //Get Referenced element and make sure it's valid
-    let refElement = getElementFromBioPax(xref[i]); 
+    let refElement = getElementFromBioPax(xrefList[i]); 
     if (!(refElement))
       continue;
 
     //create list of xrefs for eref
     if(keyName === "EntityReference"){
-      ErefXref = refElement['xref'];
-      if (typeof ErefXref == 'string')
-      ErefXref = [ErefXref];
-      if (!(ErefXref))
-      ErefXref = [];
+      let erefXref = refElement['xref'];
+      if(erefXref)
+        erefXrefList = _.concat(erefXrefList,[erefXref]);
     }
 
     //Collect data and add to tree array
@@ -114,9 +112,9 @@ function processXrefs(xref,eref,collectedData){
 
   //Also collect data for entity reference's cross-references
   //almost identically to above
-  for(let i=0;i<ErefXref.length;i++){
+  for(let i=0;i<erefXrefList.length;i++){
     let keyName = 'Reference';
-    let refElement = getElementFromBioPax(ErefXref[i]); 
+    let refElement = getElementFromBioPax(erefXrefList[i]); 
 
     if (!(refElement))
       continue;

--- a/src/server/graph-generation/biopax-metadata/index.js
+++ b/src/server/graph-generation/biopax-metadata/index.js
@@ -74,9 +74,18 @@ function buildBioPaxTree(entity) {
   if (!(xref))
     xref = [];
   let eref = entity['entityReference'];
-  if (eref) 
+  if (eref)
     xref.push(eref);
 
+  processXrefs(xref,eref,collectedData);
+  
+  result.push([id,collectedData]);
+  return result;
+}
+
+function processXrefs(xref,eref,collectedData){
+
+  let ErefXref = [];
 
   for (let i = 0; i < xref.length; i++) {
     //Check if this is a cross-reference or entity reference
@@ -85,16 +94,36 @@ function buildBioPaxTree(entity) {
       keyName = 'EntityReference';
 
     //Get Referenced element and make sure it's valid
-    let refElement = getElementFromBioPax(xref[i]);
+    let refElement = getElementFromBioPax(xref[i]); 
     if (!(refElement))
       continue;
+
+    //create list of xrefs for eref
+    if(keyName === "EntityReference"){
+      ErefXref = refElement['xref'];
+      if (typeof ErefXref == 'string')
+      ErefXref = [ErefXref];
+      if (!(ErefXref))
+      ErefXref = [];
+    }
+
     //Collect data and add to tree array
     collectedData.push([keyName,collectEntityMetadata(refElement,keyName)]);
   }
 
-  
-  result.push([id,collectedData]);
-  return result;
+
+  //Also collect data for entity reference's cross-references
+  //almost identically to above
+  for(let i=0;i<ErefXref.length;i++){
+    let keyName = 'Reference';
+    let refElement = getElementFromBioPax(ErefXref[i]); 
+
+    if (!(refElement))
+      continue;
+
+    collectedData.push([keyName,collectEntityMetadata(refElement,keyName)]);
+  }
+
 }
 
 /**

--- a/src/server/graph-generation/biopax-metadata/index.js
+++ b/src/server/graph-generation/biopax-metadata/index.js
@@ -105,7 +105,10 @@ function processXrefs(xrefList,eref,collectedData){
     if(keyName === "EntityReference"){
       let erefXref = refElement['xref'];
       if(erefXref)
-        erefXrefList = _.concat(erefXrefList,erefXref);
+        if(typeof erefXref === 'string')
+          erefXrefList = _.concat(erefXrefList,[erefXref]);
+        else
+          erefXrefList = _.concat(erefXrefList,erefXref);
     }
 
     //Collect data and add to tree array

--- a/src/server/graph-generation/biopax-metadata/index.js
+++ b/src/server/graph-generation/biopax-metadata/index.js
@@ -73,7 +73,10 @@ function buildBioPaxTree(entity) {
   let xref = entity['xref'];
   let eref = entity['entityReference'];
   if(xref)
-    xrefList = _.concat(xrefList,[xref]);
+    if(typeof xref === 'string')
+      xrefList = _.concat(xrefList,[xref]);
+    else
+      xrefList = _.concat(xrefList,xref);
   if(eref)
     xrefList = _.concat(xrefList,[eref]);
 
@@ -102,13 +105,12 @@ function processXrefs(xrefList,eref,collectedData){
     if(keyName === "EntityReference"){
       let erefXref = refElement['xref'];
       if(erefXref)
-        erefXrefList = _.concat(erefXrefList,[erefXref]);
+        erefXrefList = _.concat(erefXrefList,erefXref);
     }
 
     //Collect data and add to tree array
     collectedData.push([keyName,collectEntityMetadata(refElement,keyName)]);
   }
-
 
   //Also collect data for entity reference's cross-references
   //almost identically to above


### PR DESCRIPTION
Some pid pathways have entities with `null` data array. This was causing the tooltip display to throw an error in console.

This PR should fix some errors caused by code assuming data array was`[]` not `null`