### PR TITLE
db tests with callback had extra param

### DIFF
--- a/test/server/database/testSaveDiffs.js
+++ b/test/server/database/testSaveDiffs.js
@@ -95,7 +95,7 @@ describe('Test saveDiffs.js', function () {
   });
 
   after(function () {
-    return connection.get().then(conn => 
+    return connection.get().then(conn =>
       r.dbDrop(mockConfig.databaseName).run(conn)
     );
   });
@@ -195,7 +195,7 @@ describe('Test saveDiffs.js', function () {
 
       conn.then(conn =>
         saveDiffs.saveDiff(version.pc_id, version.release_id, newPos, user, conn, function () {
-          return query.getLayout(version.pc_id, version.release_id, conn, null,function (res) {
+          return query.getLayout(version.pc_id, version.release_id, conn, function (res) {
             expect(res).to.deep.equal(mergeDiff(layout.positions, newPos));
             done();
           });

--- a/test/server/database/testUpdate.js
+++ b/test/server/database/testUpdate.js
@@ -85,7 +85,7 @@ describe('Test update.js', function () {
 
 
   after(function () {
-    return connection.get().then(conn => 
+    return connection.get().then(conn =>
       r.dbDrop(mockConfig.databaseName).run(conn)
     );
   });
@@ -127,7 +127,7 @@ describe('Test update.js', function () {
       );
 
       let lookup = saveProm.then(() => conn).then((conn) => query.getGraph(newId, newVersion, conn));
-      
+
       return expect(lookup).to.eventually.deep.equal(existingG);
     });
 
@@ -160,7 +160,7 @@ describe('Test update.js', function () {
       let conn = connection.get();
 
       conn.then(connection => update.saveLayout(pc_id, version, newLayout, userID, connection, function () {
-        conn.then(conn => query.getLayout(pc_id, version, conn, null, function (res) {
+        conn.then(conn => query.getLayout(pc_id, version, conn, function (res) {
           expect(res).to.deep.equal(newLayout);
           done();
         }));


### PR DESCRIPTION
Re: https://github.com/PathwayCommons/app-ui/issues/811#issuecomment-397332484

Fixes failing db tests for `optionally accepts a callback`. There was some extra null parameter.