### PR TITLE
 geneCount mapped to node size #902

### DIFF
--- a/src/client/common/cy/enrichment-stylesheet.js
+++ b/src/client/common/cy/enrichment-stylesheet.js
@@ -28,7 +28,7 @@ const enrichmentStylesheet=cytoscape.stylesheet()
 .css({
   'font-size': 20,
   'color': 'black',
-  'background-color': '	#00bfff', //TODO: Colored accoriding to p-value
+  'background-color': '#00bfff', //TODO: Colored accoriding to p-value
   'background-opacity':0.8,
   'text-outline-color': 'white',
   'text-outline-width': 2,

--- a/src/client/common/cy/enrichment-stylesheet.js
+++ b/src/client/common/cy/enrichment-stylesheet.js
@@ -1,5 +1,13 @@
 const cytoscape = require('cytoscape');
 
+function nodeSize(geneCount){
+  console.log(geneCount);
+  //let size = geneCount;
+  let size = (5*Math.sqrt(geneCount -1)+30);
+  //let size = (geneCount/2) + 30;
+  return size;
+}
+
 const iStylesheet=cytoscape.stylesheet()
 .selector('edge')
 .css({
@@ -25,8 +33,8 @@ const iStylesheet=cytoscape.stylesheet()
   'text-outline-width': 2,
   'text-wrap': 'wrap',
   'text-max-width': 175,
-  'width': node => node.data('size') ? node.data('size') : 30,
-  'height': node => node.data('size') ? node.data('size') : 30,
+  'width': node => node.data('geneCount') ? nodeSize(node.data('geneCount')) : 30,
+  'height': node => node.data('geneCount') ? nodeSize(node.data('geneCount')) : 30,
   'label': node => node.data('description'),
   'text-halign': 'center',
   'text-valign': 'center',

--- a/src/client/common/cy/enrichment-stylesheet.js
+++ b/src/client/common/cy/enrichment-stylesheet.js
@@ -1,14 +1,15 @@
 const cytoscape = require('cytoscape');
 
-function nodeSize(geneCount){
-  console.log(geneCount);
-  //let size = geneCount;
-  let size = (5*Math.sqrt(geneCount -1)+30);
-  //let size = (geneCount/2) + 30;
+function getNodeSize( geneCount ){
+  let size = ( geneCount <= 1000 ) ? mapGeneCountToSize(geneCount) : mapGeneCountToSize(1000);
   return size;
 }
 
-const iStylesheet=cytoscape.stylesheet()
+function mapGeneCountToSize( geneCount ){
+  return ( (5 * Math.sqrt( geneCount -1 )) + 30 );
+}
+
+const enrichmentStylesheet=cytoscape.stylesheet()
 .selector('edge')
 .css({
   'opacity': 0.3,
@@ -33,8 +34,8 @@ const iStylesheet=cytoscape.stylesheet()
   'text-outline-width': 2,
   'text-wrap': 'wrap',
   'text-max-width': 175,
-  'width': node => node.data('geneCount') ? nodeSize(node.data('geneCount')) : 30,
-  'height': node => node.data('geneCount') ? nodeSize(node.data('geneCount')) : 30,
+  'width': node => node.data('geneCount') ? getNodeSize(node.data('geneCount')) : 30,
+  'height': node => node.data('geneCount') ? getNodeSize(node.data('geneCount')) : 30,
   'label': node => node.data('description'),
   'text-halign': 'center',
   'text-valign': 'center',
@@ -47,4 +48,4 @@ const iStylesheet=cytoscape.stylesheet()
   'color': 'white',
   'text-outline-color': 'black'
 });
-module.exports = iStylesheet;
+module.exports = enrichmentStylesheet;

--- a/src/client/common/cy/layout/index.js
+++ b/src/client/common/cy/layout/index.js
@@ -72,6 +72,18 @@ const interactionsLayout = {
   }
 };
 
+const enrichmentLayout = {
+  displayName: 'cose-bilkent',
+  description: 'The CoSE layout for Cytoscape.js by the i-Vis Lab in Bilkent University',
+  options: {
+    name: 'cose-bilkent',
+    nodeRepulsion: 300000,
+    edgeElasticity: 0.05,
+    idealEdgeLength: 200,
+    animate:false,
+  }
+};
+
 const getLayoutConfig = (presetLayoutJSON) => {
   const humanCreatedLayout = {
     name: 'preset',
@@ -98,6 +110,12 @@ const getLayoutConfig = (presetLayoutJSON) => {
     layoutConfig = {
       defaultLayout: interactionsLayout,
       layouts: [interactionsLayout]
+    };
+  }
+  else if(presetLayoutJSON === 'enrichment'){
+    layoutConfig = {
+      defaultLayout: enrichmentLayout,
+      layouts: [enrichmentLayout]
     };
   }
   else {

--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -36,7 +36,7 @@ class Enrichment extends React.Component {
     this.state = {
       cySrv: new CytoscapeService( {style: enrichmentStylesheet, showTooltipsOnEdges:true, minZoom:0.01 }),
       componentConfig: enrichmentConfig,
-      layoutConfig: getLayoutConfig(),
+      layoutConfig: getLayoutConfig('enrichment'),
       networkJSON: emptyNetworkJSON,
 
       networkMetadata: {

--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -29,6 +29,24 @@ const emptyNetworkJSON = {
     nodes: []
 };
 
+// for testing purposes
+// const testNetwork = {
+//   edges: [
+//     {data:{id: 'edge1', source:"node3", target: "node4", similarity: 3 }},
+//     {data:{id: 'edge2', source:"node1", target: "node2", similarity: .4 }},
+//     {data:{id: 'edge3', source:"node1", target: "node4" }},
+//     {data:{id: 'edge4', source:"node2", target: "node4" }}
+//   ],
+//   nodes: [
+//     {data: {id: "node1", description: "node1", p_value: ".1", geneCount: "100000"}},
+//     {data: {id: "node2", description: "node2", p_value: ".05", geneCount: "1"}},
+//     {data: {id: "node3", description: "node3", p_value: ".05", geneCount: "100"}},
+//     {data: {id: "node4", description: "node4", p_value: ".025", geneCount: "500"}},
+//     {data: {id: "node5", description: "node5", p_value: ".75", geneCount: "300"}},
+//     {data: {id: "node6", description: "node6", p_value: ".9999"}}
+//   ]
+// };
+
 
 class Enrichment extends React.Component {
   constructor(props) {
@@ -38,6 +56,7 @@ class Enrichment extends React.Component {
       componentConfig: enrichmentConfig,
       layoutConfig: getLayoutConfig('enrichment'),
       networkJSON: emptyNetworkJSON,
+      // networkJSON: testNetwork,
 
       networkMetadata: {
         name: "enrichment",


### PR DESCRIPTION
- mathematically map geneCount to enrichment node size
- default and smallest node size = 30
- largest node size = 188 ( when geneCount >= 1000 )
- increase nodeRepulsion so nodes do not overlap