### PR TITLE
Collapse input box #917

### DIFF
--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -128,7 +128,7 @@ class Enrichment extends React.Component {
   }
 
   render() {
-    let { cySrv, componentConfig, layoutConfig, networkJSON, networkMetadata, networkLoading, closeToolBar, loaded } = this.state;
+    let { cySrv, componentConfig, layoutConfig, networkJSON, networkMetadata, networkLoading, closeToolBar, loaded, unrecognized } = this.state;
 
     let retrieveTokenInput = () => h(TokenInput,{
       inputs: this.state.inputs,
@@ -164,8 +164,10 @@ class Enrichment extends React.Component {
     //display baseView or loading spinner
     const content = loaded ? baseView : loadingView;
     return h('div.main', {
-      onClick: (e) => { if( e.target.id !== 'gene-input-box' ) document.getElementById('gene-input-box').blur(); }, //click to hide input box
-      onLoad: () => document.getElementById('gene-input-box').focus() //focus and expand input box when new network loaded
+      //click off input box to hide
+      onClick: (e) => { if( e.target.id !== 'gene-input-box' ) document.getElementById('gene-input-box').blur(); },
+      //open input and unrecognized boxes onLoad only if unrecognized tokens exist
+      onLoad: () => { if( _.isEmpty(unrecognized) == false ) document.getElementById('gene-input-box').focus(); }
     },
     [content]);
   }

--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -163,7 +163,11 @@ class Enrichment extends React.Component {
 
     //display baseView or loading spinner
     const content = loaded ? baseView : loadingView;
-    return h('div.main', [content]);
+    return h('div.main', {
+      onClick: (e) => { if( e.target.id !== 'gene-input-box' ) document.getElementById('gene-input-box').blur(); }, //click to hide input box
+      onLoad: () => document.getElementById('gene-input-box').focus() //focus and expand input box when new network loaded
+    },
+    [content]);
   }
 }
 

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -22,7 +22,7 @@ class TokenInput extends React.Component {
 
   //only open unrecognized feedback if unrecognized tokens exist
   handleFocus(){
-    if( _.isEmpty(this.props.unrecognized) == false ) this.setState({openUnrecognized: true});
+    this.setState({openUnrecognized: true});
   }
 
   //close unrecognized feedback when input box is closed
@@ -77,13 +77,14 @@ class TokenInput extends React.Component {
           onClick: () => { this.retrieveValidationAPIResult();} },
           [h('button.submit', 'Submit')]
         ),
-        h('div.unrecognized-token-container',[
+        h('div.unrecognized-token-container',{ style: { display: state.openUnrecognized ? 'block' : 'none' }},[
           h(Textarea, {
+            id: 'unrecognized-tokens-feedback',
             className:'unrecognized-tokens-feedback',
             value: "Unrecognized Tokens: \n" + unrecognized.join("\n"),
             readOnly: true,
             //only display when input box is open and unrecognized tokens exist
-            style: { display: state.openUnrecognized ? 'block' : 'none' }
+            style: { display: _.isEmpty(this.props.unrecognized) ? 'none' : 'block' }
           })
         ])
     ]);

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -11,12 +11,23 @@ class TokenInput extends React.Component {
     // Note on input contents: Set the initial value here from parent
     // in order to maintain contents on re-render.
     this.state = {
-      inputBoxContents: this.props.inputs
+      inputBoxContents: this.props.inputs,
+      openUnrecognized: false
     };
   }
   //store 'gene-input-box' contents on state
   handleChange(e) {
     this.setState({inputBoxContents: e.target.value});
+  }
+
+  //only open unrecognized feedback if unrecognized tokens exist
+  handleFocus(){
+    if( _.isEmpty(this.props.unrecognized) == false ) this.setState({openUnrecognized: true});
+  }
+
+  //close unrecognized feedback when input box is closed
+  handleBlur(){
+    this.setState({openUnrecognized: false});
   }
 
   //call validation service API to retrieve validation result in the form of []
@@ -42,6 +53,7 @@ class TokenInput extends React.Component {
   render() {
 
     const unrecognized = this.props.unrecognized;
+    const state = this.state;
 
     return h('div.enrichmentInput', [
         h('h4', [
@@ -52,10 +64,13 @@ class TokenInput extends React.Component {
         }),
         h('div.gene-input-container', [
           h(Textarea, {
-            className: 'gene-input-box',
+            id: 'gene-input-box', // for focus() and blur()
+            className: 'gene-input-box', // used for css styling
             placeholder: 'Enter one gene per line',
-            value: this.state.inputBoxContents,
-            onChange: (e) => this.handleChange(e)
+            value: state.inputBoxContents,
+            onChange: (e) => this.handleChange(e),
+            onFocus: () => this.handleFocus(),
+            onBlur: () => this.handleBlur()
           })
         ]),
         h('submit-container', {
@@ -67,8 +82,8 @@ class TokenInput extends React.Component {
             className:'unrecognized-tokens-feedback',
             value: "Unrecognized Tokens: \n" + unrecognized.join("\n"),
             readOnly: true,
-            //if unrecognizedTokens is its default value (ie no tokens have been added), feedback box not displayed
-            style: {display: _.isEmpty( unrecognized ) ? 'none' : 'block' }
+            //only display when input box is open and unrecognized tokens exist
+            style: { display: state.openUnrecognized ? 'block' : 'none' }
           })
         ])
     ]);

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -20,7 +20,7 @@ class TokenInput extends React.Component {
     this.setState({inputBoxContents: e.target.value});
   }
 
-  //only open unrecognized feedback if unrecognized tokens exist
+  //only open unrecognized feedback if input box has focus
   handleFocus(){
     this.setState({openUnrecognized: true});
   }
@@ -83,7 +83,7 @@ class TokenInput extends React.Component {
             className:'unrecognized-tokens-feedback',
             value: "Unrecognized Tokens: \n" + unrecognized.join("\n"),
             readOnly: true,
-            //only display when input box is open and unrecognized tokens exist
+            //only display when container is open and unrecognized tokens exist
             style: { display: _.isEmpty(this.props.unrecognized) ? 'none' : 'block' }
           })
         ])

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -36,12 +36,11 @@
 }
 
 .unrecognized-token-container{
-  @extend %flex-center;
-
   min-width: 200px;
   position: absolute;
   top: 100%;
   left: -1px;
+  z-index: 1;
 }
 
 .unrecognized-tokens-feedback{


### PR DESCRIPTION
- Click anywhere on screen to close input box
- Synchronize the opening and closing of unrecognized token feedback box
- Open input box (and unrecognized box if invalid tokens exist) when network is loaded

***Remaining issue: clicking/trying to highlight the unrecognized tokens box will cause the input box to lose focus, and, as a result, both boxes close.