### PR TITLE
Expand collapse cue

### DIFF
--- a/src/client/features/pathways/cy/events.js
+++ b/src/client/features/pathways/cy/events.js
@@ -103,6 +103,7 @@ let bindCyEvents = cy => {
 
   cy.on('mouseover', '.cy-expand-collapse-collapsed-node', nodeHoverExpandCollapse);
 
+  cy.on('mouseout', '$node > node', () => hideCues());
   cy.on('drag', () => hideCues());
   cy.on('pan', () => hideCues());
   cy.on('zoom', () => hideCues());

--- a/src/client/features/pathways/cy/events.js
+++ b/src/client/features/pathways/cy/events.js
@@ -73,7 +73,7 @@ let bindCyEvents = cy => {
   cy.on('pan', () => hideTooltips());
   cy.on('zoom', () => hideTooltips());
   cy.on('layoutstart', () => hideTooltips());
-  cy.on('expandcollapse.aftercollapse', () => hideTooltips());
+  cy.on('expandcollapse.beforecollapse', () => hideTooltips());
 
   let nodeHoverExpandCollapse = _.debounce(evt => {
     let node = evt.target;
@@ -97,7 +97,7 @@ let bindCyEvents = cy => {
       ecCue.show();
     }
 
-  }, 200);
+  }, 1);
 
   cy.on('mouseover', '$node > node', nodeHoverExpandCollapse);
 

--- a/src/client/features/pathways/cy/events.js
+++ b/src/client/features/pathways/cy/events.js
@@ -73,6 +73,7 @@ let bindCyEvents = cy => {
   cy.on('pan', () => hideTooltips());
   cy.on('zoom', () => hideTooltips());
   cy.on('layoutstart', () => hideTooltips());
+  cy.on('expandcollapse.aftercollapse', () => hideTooltips());
 
   let nodeHoverExpandCollapse = _.debounce(evt => {
     let node = evt.target;

--- a/src/client/features/pathways/cy/events.js
+++ b/src/client/features/pathways/cy/events.js
@@ -97,7 +97,7 @@ let bindCyEvents = cy => {
       ecCue.show();
     }
 
-  }, 1);
+  }, 200);
 
   cy.on('mouseover', '$node > node', nodeHoverExpandCollapse);
 
@@ -107,6 +107,7 @@ let bindCyEvents = cy => {
   cy.on('pan', () => hideCues());
   cy.on('zoom', () => hideCues());
   cy.on('layoutstart', () => hideCues());
+  cy.on('tap', () => hideCues());
 
 
 

--- a/src/client/features/pathways/cy/expand-collapse-cue.js
+++ b/src/client/features/pathways/cy/expand-collapse-cue.js
@@ -60,11 +60,11 @@ class ExpandCollapseCueTip {
     }
 
 
-    let rbb = this.node.renderedBoundingBox();
-    let ecAPI = this.node._private.cy.expandCollapse('get');
-    let cueXOffset = ecAPI.isCollapsible(this.node) ? 0 : .4 * rbb.w;
+    let rbb = this.node.renderedBoundingBox({
+      includeLabels: false
+    });
     let refObject = this.node.popperRef({
-      renderedPosition: () => ({ x: rbb.x1 + cueXOffset, y: rbb.y1}),
+      renderedPosition: () => ({ x: rbb.x1, y: rbb.y1}),
       renderedDimensions: () => ({w: 3, h: 3})
     });
     let tooltip = tippy(refObject, {
@@ -75,7 +75,7 @@ class ExpandCollapseCueTip {
       hideOnClick: false,
       arrow: false,
       placement: 'bottom-end',
-      // size: 'regular',
+      size: 'small',
       offset: '50, 0',
       flip: false,
       distance: 0}

--- a/src/client/features/pathways/cy/expand-collapse-cue.js
+++ b/src/client/features/pathways/cy/expand-collapse-cue.js
@@ -34,7 +34,7 @@ class ExpandCollapseCue extends React.Component {
   render(){
     let { collapsed } = this.state;
     return h('div.expand-collapse-cue', { onClick: () => this.handleClick() }, [
-      h('i.material-icons', collapsed ? 'add_circle' : 'remove_circle')
+      h('i.material-icons', collapsed ? 'unfold_more' : 'unfold_less')
     ]);
   }
 }

--- a/src/client/features/pathways/cy/expand-collapse-cue.js
+++ b/src/client/features/pathways/cy/expand-collapse-cue.js
@@ -75,7 +75,6 @@ class ExpandCollapseCueTip {
       hideOnClick: false,
       arrow: false,
       placement: 'bottom-end',
-      size: 'small',
       offset: '50, 0',
       flip: false,
       distance: 0}

--- a/src/client/features/pathways/cy/expand-collapse-cue.js
+++ b/src/client/features/pathways/cy/expand-collapse-cue.js
@@ -1,0 +1,95 @@
+const React = require('react');
+const ReactDom = require('react-dom');
+const hh = require('hyperscript');
+const h = require('react-hyperscript');
+const tippy = require('tippy.js');
+
+class ExpandCollapseCue extends React.Component {
+  constructor(props){
+    super(props);
+    let { node } = this.props;
+    let ecAPI = node._private.cy.expandCollapse('get');
+
+    this.state = {
+      collapsed: !ecAPI.isCollapsible(node)
+    };
+  }
+
+  handleClick(){
+    let { node } = this.props;
+    let { collapsed } = this.state;
+    let ecAPI = node._private.cy.expandCollapse('get');
+
+    if( collapsed ){
+      ecAPI.expandRecursively(node);
+    } else {
+      ecAPI.collapseRecursively(node);
+    }
+
+    this.setState({
+      collapsed: !collapsed
+    });
+  }
+
+  render(){
+    let { collapsed } = this.state;
+    return h('div.expand-collapse-cue', { onClick: () => this.handleClick() }, [
+      h('i.material-icons', collapsed ? 'add_circle' : 'remove_circle')
+    ]);
+  }
+}
+
+// This metadata tip is only for entities i.e. nodes
+// TODO make an edge metadata tip for edges (for the interactions app)
+class ExpandCollapseCueTip {
+  constructor(node) {
+    this.node = node;
+    this.tooltip = null;
+  }
+
+  show() {
+    let getContentDiv = component => {
+      let div = hh('div');
+      ReactDom.render( component, div );
+      return div;
+    };
+
+    if( this.tooltip != null ){
+      this.tooltip.destroy();
+      this.tooltip = null;
+    }
+
+
+    let rbb = this.node.renderedBoundingBox();
+    let ecAPI = this.node._private.cy.expandCollapse('get');
+    let cueXOffset = ecAPI.isCollapsible(this.node) ? 0 : .4 * rbb.w;
+    let refObject = this.node.popperRef({
+      renderedPosition: () => ({ x: rbb.x1 + cueXOffset, y: rbb.y1}),
+      renderedDimensions: () => ({w: 3, h: 3})
+    });
+    let tooltip = tippy(refObject, {
+      html: getContentDiv( h(ExpandCollapseCue, { node: this.node, } )),
+      theme: 'dark',
+      interactive: true,
+      trigger: 'manual',
+      hideOnClick: false,
+      arrow: false,
+      placement: 'bottom-end',
+      // size: 'regular',
+      offset: '50, 0',
+      flip: false,
+      distance: 0}
+    ).tooltips[0];
+
+    this.tooltip = tooltip;
+    this.tooltip.show();
+  }
+
+  hide() {
+    if (this.tooltip) {
+      this.tooltip.hide();
+    }
+  }
+}
+
+module.exports = ExpandCollapseCueTip;

--- a/src/client/features/pathways/cy/expand-collapse-cue.js
+++ b/src/client/features/pathways/cy/expand-collapse-cue.js
@@ -65,7 +65,7 @@ class ExpandCollapseCueTip {
     });
     let refObject = this.node.popperRef({
       renderedPosition: () => ({ x: rbb.x1, y: rbb.y1}),
-      renderedDimensions: () => ({w: 3, h: 3})
+      renderedDimensions: () => ({w: -5, h: -5})
     });
     let tooltip = tippy(refObject, {
       html: getContentDiv( h(ExpandCollapseCue, { node: this.node, } )),

--- a/src/client/features/pathways/cy/layout.js
+++ b/src/client/features/pathways/cy/layout.js
@@ -3,7 +3,7 @@ module.exports = {
     name: 'cose-bilkent',
     nodeRepulsion: 5000,
     nodeDimensionsIncludeLabels: true,
-    tilingPaddingVertical: 20,
+    tilingPaddingVertical: 50,
     tilingPaddingHorizontal: 20,
     animate: true,
     animationDuration: 500,

--- a/src/client/features/pathways/cy/pathways-stylesheet.js
+++ b/src/client/features/pathways/cy/pathways-stylesheet.js
@@ -39,6 +39,10 @@ module.exports = sbgnStyleSheet(cytoscape)
   'font-size': 20,
   'text-max-width': 175
 })
+.selector('.cy-expand-collapse-meta-edge')
+.css({
+  'line-style': 'dashed'
+})
 .selector('edge')
 .css({
   'opacity': 0.3

--- a/src/styles/features/pathways/tooltip.css
+++ b/src/styles/features/pathways/tooltip.css
@@ -44,7 +44,7 @@
   background-color: var(--light-base-colour-dark);
   font-size: 0.9em;
   color: black;
-	border-radius: 10px;
+  border-radius: 10px;
 }
 
 .metadata-tooltip-body {
@@ -106,6 +106,7 @@
   justify-content: center;
   align-items: center;
 }
+
 .metadata-find-pathways {
   margin: 3px;
   margin-top: 10px;
@@ -126,4 +127,8 @@
   & a {
     color: var(--activeColor);
   }
+}
+
+.expand-collapse-cue {
+  cursor: pointer;
 }

--- a/src/styles/features/pathways/tooltip.css
+++ b/src/styles/features/pathways/tooltip.css
@@ -134,3 +134,7 @@
   padding: 3px;
   font-size: 1.5em;
 }
+
+.expand-collapse-cue:hover {
+  color: var(--accent-1-colour);
+}

--- a/src/styles/features/pathways/tooltip.css
+++ b/src/styles/features/pathways/tooltip.css
@@ -8,6 +8,7 @@
   border-radius: 0;
   color: black;
   text-align: left;
+  padding: 10px;
 }
 
 .metadata-tooltip-content {
@@ -117,6 +118,7 @@
   border: 1px solid var(--light-base-colour-darker);
   color: var(--activeColor);
   box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+  border-radius: 5px;
 }
 
 .metadata-publication {

--- a/src/styles/features/pathways/tooltip.css
+++ b/src/styles/features/pathways/tooltip.css
@@ -1,3 +1,7 @@
+.tooltip-description {
+  padding: 0 1em;
+}
+
 .metadata-tooltip {
   max-width: 300px;
   min-width: 10em;

--- a/src/styles/features/pathways/tooltip.css
+++ b/src/styles/features/pathways/tooltip.css
@@ -131,5 +131,6 @@
 
 .expand-collapse-cue {
   cursor: pointer;
-  font-size: 1.25em;
+  padding: 3px;
+  font-size: 1.5em;
 }

--- a/src/styles/features/pathways/tooltip.css
+++ b/src/styles/features/pathways/tooltip.css
@@ -131,4 +131,5 @@
 
 .expand-collapse-cue {
   cursor: pointer;
+  font-size: 1.25em;
 }

--- a/src/styles/vendor/tippy.css
+++ b/src/styles/vendor/tippy.css
@@ -300,7 +300,6 @@
   border-top: 7px solid transparent;
   border-bottom: 7px solid transparent;
   right: -7px;
-  margin: 6px 0
 }
 
 .tippy-popper[x-placement^=left] [x-arrow].arrow-small {
@@ -590,21 +589,19 @@
   color: #fff;
   border-radius: 4px;
   font-size: .95rem;
-  padding: .4rem .8rem;
   text-align: center;
   will-change: transform;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #333
+  background-color: #333;
+  padding: 0;
 }
 
 .tippy-tooltip--small {
-  padding: .25rem .5rem;
   font-size: .8rem
 }
 
 .tippy-tooltip--big {
-  padding: .6rem 1.2rem;
   font-size: 1.2rem
 }
 

--- a/src/styles/vendor/tippy.css
+++ b/src/styles/vendor/tippy.css
@@ -1,1 +1,657 @@
-.tippy-touch{cursor:pointer!important}.tippy-notransition{-webkit-transition:none!important;transition:none!important}.tippy-popper{max-width:400px;-webkit-perspective:800px;perspective:800px;z-index:9999;outline:0;-webkit-transition-timing-function:cubic-bezier(.165,.84,.44,1);transition-timing-function:cubic-bezier(.165,.84,.44,1);pointer-events:none}.tippy-popper.html-template{max-width:96%;max-width:calc(100% - 20px)}.tippy-popper[x-placement^=top] [x-arrow]{border-top:7px solid #333;border-right:7px solid transparent;border-left:7px solid transparent;bottom:-7px;margin:0 9px}.tippy-popper[x-placement^=top] [x-arrow].arrow-small{border-top:5px solid #333;border-right:5px solid transparent;border-left:5px solid transparent;bottom:-5px}.tippy-popper[x-placement^=top] [x-arrow].arrow-big{border-top:10px solid #333;border-right:10px solid transparent;border-left:10px solid transparent;bottom:-10px}.tippy-popper[x-placement^=top] [x-circle]{-webkit-transform-origin:0 33%;transform-origin:0 33%}.tippy-popper[x-placement^=top] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-55%);transform:scale(1) translate(-50%,-55%);opacity:1}.tippy-popper[x-placement^=top] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-50%);transform:scale(.15) translate(-50%,-50%);opacity:0}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow]{border-top:7px solid #fff;border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-top:5px solid #fff;border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-top:10px solid #fff;border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow]{border-top:7px solid rgba(0,0,0,.7);border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-top:5px solid rgba(0,0,0,.7);border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-top:10px solid rgba(0,0,0,.7);border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=top] [data-animation=perspective]{-webkit-transform-origin:bottom;transform-origin:bottom}.tippy-popper[x-placement^=top] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateY(-10px) rotateX(0);transform:translateY(-10px) rotateX(0)}.tippy-popper[x-placement^=top] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateY(0) rotateX(90deg);transform:translateY(0) rotateX(90deg)}.tippy-popper[x-placement^=top] [data-animation=fade].enter{opacity:1;-webkit-transform:translateY(-10px);transform:translateY(-10px)}.tippy-popper[x-placement^=top] [data-animation=fade].leave{opacity:0;-webkit-transform:translateY(-10px);transform:translateY(-10px)}.tippy-popper[x-placement^=top] [data-animation=shift].enter{opacity:1;-webkit-transform:translateY(-10px);transform:translateY(-10px)}.tippy-popper[x-placement^=top] [data-animation=shift].leave{opacity:0;-webkit-transform:translateY(0);transform:translateY(0)}.tippy-popper[x-placement^=top] [data-animation=scale].enter{opacity:1;-webkit-transform:translateY(-10px) scale(1);transform:translateY(-10px) scale(1)}.tippy-popper[x-placement^=top] [data-animation=scale].leave{opacity:0;-webkit-transform:translateY(0) scale(0);transform:translateY(0) scale(0)}.tippy-popper[x-placement^=bottom] [x-arrow]{border-bottom:7px solid #333;border-right:7px solid transparent;border-left:7px solid transparent;top:-7px;margin:0 9px}.tippy-popper[x-placement^=bottom] [x-arrow].arrow-small{border-bottom:5px solid #333;border-right:5px solid transparent;border-left:5px solid transparent;top:-5px}.tippy-popper[x-placement^=bottom] [x-arrow].arrow-big{border-bottom:10px solid #333;border-right:10px solid transparent;border-left:10px solid transparent;top:-10px}.tippy-popper[x-placement^=bottom] [x-circle]{-webkit-transform-origin:0 -50%;transform-origin:0 -50%}.tippy-popper[x-placement^=bottom] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-45%);transform:scale(1) translate(-50%,-45%);opacity:1}.tippy-popper[x-placement^=bottom] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-5%);transform:scale(.15) translate(-50%,-5%);opacity:0}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow]{border-bottom:7px solid #fff;border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-bottom:5px solid #fff;border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-bottom:10px solid #fff;border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow]{border-bottom:7px solid rgba(0,0,0,.7);border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-bottom:5px solid rgba(0,0,0,.7);border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-bottom:10px solid rgba(0,0,0,.7);border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=bottom] [data-animation=perspective]{-webkit-transform-origin:top;transform-origin:top}.tippy-popper[x-placement^=bottom] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateY(10px) rotateX(0);transform:translateY(10px) rotateX(0)}.tippy-popper[x-placement^=bottom] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateY(0) rotateX(-90deg);transform:translateY(0) rotateX(-90deg)}.tippy-popper[x-placement^=bottom] [data-animation=fade].enter{opacity:1;-webkit-transform:translateY(10px);transform:translateY(10px)}.tippy-popper[x-placement^=bottom] [data-animation=fade].leave{opacity:0;-webkit-transform:translateY(10px);transform:translateY(10px)}.tippy-popper[x-placement^=bottom] [data-animation=shift].enter{opacity:1;-webkit-transform:translateY(10px);transform:translateY(10px)}.tippy-popper[x-placement^=bottom] [data-animation=shift].leave{opacity:0;-webkit-transform:translateY(0);transform:translateY(0)}.tippy-popper[x-placement^=bottom] [data-animation=scale].enter{opacity:1;-webkit-transform:translateY(10px) scale(1);transform:translateY(10px) scale(1)}.tippy-popper[x-placement^=bottom] [data-animation=scale].leave{opacity:0;-webkit-transform:translateY(0) scale(0);transform:translateY(0) scale(0)}.tippy-popper[x-placement^=left] [x-arrow]{border-left:7px solid #333;border-top:7px solid transparent;border-bottom:7px solid transparent;right:-7px;margin:6px 0}.tippy-popper[x-placement^=left] [x-arrow].arrow-small{border-left:5px solid #333;border-top:5px solid transparent;border-bottom:5px solid transparent;right:-5px}.tippy-popper[x-placement^=left] [x-arrow].arrow-big{border-left:10px solid #333;border-top:10px solid transparent;border-bottom:10px solid transparent;right:-10px}.tippy-popper[x-placement^=left] [x-circle]{-webkit-transform-origin:50% 0;transform-origin:50% 0}.tippy-popper[x-placement^=left] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-50%);transform:scale(1) translate(-50%,-50%);opacity:1}.tippy-popper[x-placement^=left] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-50%);transform:scale(.15) translate(-50%,-50%);opacity:0}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow]{border-left:7px solid #fff;border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-left:5px solid #fff;border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-left:10px solid #fff;border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow]{border-left:7px solid rgba(0,0,0,.7);border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-left:5px solid rgba(0,0,0,.7);border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-left:10px solid rgba(0,0,0,.7);border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=left] [data-animation=perspective]{-webkit-transform-origin:right;transform-origin:right}.tippy-popper[x-placement^=left] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateX(-10px) rotateY(0);transform:translateX(-10px) rotateY(0)}.tippy-popper[x-placement^=left] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateX(0) rotateY(-90deg);transform:translateX(0) rotateY(-90deg)}.tippy-popper[x-placement^=left] [data-animation=fade].enter{opacity:1;-webkit-transform:translateX(-10px);transform:translateX(-10px)}.tippy-popper[x-placement^=left] [data-animation=fade].leave{opacity:0;-webkit-transform:translateX(-10px);transform:translateX(-10px)}.tippy-popper[x-placement^=left] [data-animation=shift].enter{opacity:1;-webkit-transform:translateX(-10px);transform:translateX(-10px)}.tippy-popper[x-placement^=left] [data-animation=shift].leave{opacity:0;-webkit-transform:translateX(0);transform:translateX(0)}.tippy-popper[x-placement^=left] [data-animation=scale].enter{opacity:1;-webkit-transform:translateX(-10px) scale(1);transform:translateX(-10px) scale(1)}.tippy-popper[x-placement^=left] [data-animation=scale].leave{opacity:0;-webkit-transform:translateX(0) scale(0);transform:translateX(0) scale(0)}.tippy-popper[x-placement^=right] [x-arrow]{border-right:7px solid #333;border-top:7px solid transparent;border-bottom:7px solid transparent;left:-7px;margin:6px 0}.tippy-popper[x-placement^=right] [x-arrow].arrow-small{border-right:5px solid #333;border-top:5px solid transparent;border-bottom:5px solid transparent;left:-5px}.tippy-popper[x-placement^=right] [x-arrow].arrow-big{border-right:10px solid #333;border-top:10px solid transparent;border-bottom:10px solid transparent;left:-10px}.tippy-popper[x-placement^=right] [x-circle]{-webkit-transform-origin:-50% 0;transform-origin:-50% 0}.tippy-popper[x-placement^=right] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-50%);transform:scale(1) translate(-50%,-50%);opacity:1}.tippy-popper[x-placement^=right] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-50%);transform:scale(.15) translate(-50%,-50%);opacity:0}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow]{border-right:7px solid #fff;border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-right:5px solid #fff;border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-right:10px solid #fff;border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow]{border-right:7px solid rgba(0,0,0,.7);border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-right:5px solid rgba(0,0,0,.7);border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-right:10px solid rgba(0,0,0,.7);border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=right] [data-animation=perspective]{-webkit-transform-origin:left;transform-origin:left}.tippy-popper[x-placement^=right] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateX(10px) rotateY(0);transform:translateX(10px) rotateY(0)}.tippy-popper[x-placement^=right] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateX(0) rotateY(90deg);transform:translateX(0) rotateY(90deg)}.tippy-popper[x-placement^=right] [data-animation=fade].enter{opacity:1;-webkit-transform:translateX(10px);transform:translateX(10px)}.tippy-popper[x-placement^=right] [data-animation=fade].leave{opacity:0;-webkit-transform:translateX(10px);transform:translateX(10px)}.tippy-popper[x-placement^=right] [data-animation=shift].enter{opacity:1;-webkit-transform:translateX(10px);transform:translateX(10px)}.tippy-popper[x-placement^=right] [data-animation=shift].leave{opacity:0;-webkit-transform:translateX(0);transform:translateX(0)}.tippy-popper[x-placement^=right] [data-animation=scale].enter{opacity:1;-webkit-transform:translateX(10px) scale(1);transform:translateX(10px) scale(1)}.tippy-popper[x-placement^=right] [data-animation=scale].leave{opacity:0;-webkit-transform:translateX(0) scale(0);transform:translateX(0) scale(0)}.tippy-popper .tippy-tooltip.transparent-theme{background-color:rgba(0,0,0,.7)}.tippy-popper .tippy-tooltip.transparent-theme[data-animatefill]{background-color:transparent}.tippy-popper .tippy-tooltip.light-theme{color:#26323d;box-shadow:0 4px 20px 4px rgba(0,20,60,.1),0 4px 80px -8px rgba(0,20,60,.2);background-color:#fff}.tippy-popper .tippy-tooltip.light-theme[data-animatefill]{background-color:transparent}.tippy-tooltip{position:relative;color:#fff;border-radius:4px;font-size:.95rem;padding:.4rem .8rem;text-align:center;will-change:transform;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;background-color:#333}.tippy-tooltip--small{padding:.25rem .5rem;font-size:.8rem}.tippy-tooltip--big{padding:.6rem 1.2rem;font-size:1.2rem}.tippy-tooltip[data-animatefill]{overflow:hidden;background-color:transparent}.tippy-tooltip[data-interactive]{pointer-events:auto}.tippy-tooltip[data-inertia]{-webkit-transition-timing-function:cubic-bezier(.53,1,.36,.85);transition-timing-function:cubic-bezier(.53,2,.36,.85)}.tippy-tooltip [x-arrow]{position:absolute;width:0;height:0}.tippy-tooltip [x-circle]{position:absolute;will-change:transform;background-color:#333;border-radius:50%;width:130%;width:calc(110% + 2rem);left:50%;top:50%;z-index:-1;overflow:hidden;-webkit-transition:all ease;transition:all ease}.tippy-tooltip [x-circle]:before{content:"";padding-top:90%;float:left}@media (max-width:450px){.tippy-popper{max-width:96%;max-width:calc(100% - 20px)}}
+.tippy-touch {
+  cursor: pointer!important
+}
+
+.tippy-notransition {
+  -webkit-transition: none!important;
+  transition: none!important
+}
+
+.tippy-popper {
+  max-width: 400px;
+  -webkit-perspective: 800px;
+  perspective: 800px;
+  z-index: 9999;
+  outline: 0;
+  -webkit-transition-timing-function: cubic-bezier(.165, .84, .44, 1);
+  transition-timing-function: cubic-bezier(.165, .84, .44, 1);
+  pointer-events: none
+}
+
+.tippy-popper.html-template {
+  max-width: 96%;
+  max-width: calc(100% - 20px)
+}
+
+.tippy-popper[x-placement^=top] [x-arrow] {
+  border-top: 7px solid #333;
+  border-right: 7px solid transparent;
+  border-left: 7px solid transparent;
+  bottom: -7px;
+  margin: 0 9px
+}
+
+.tippy-popper[x-placement^=top] [x-arrow].arrow-small {
+  border-top: 5px solid #333;
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  bottom: -5px
+}
+
+.tippy-popper[x-placement^=top] [x-arrow].arrow-big {
+  border-top: 10px solid #333;
+  border-right: 10px solid transparent;
+  border-left: 10px solid transparent;
+  bottom: -10px
+}
+
+.tippy-popper[x-placement^=top] [x-circle] {
+  -webkit-transform-origin: 0 33%;
+  transform-origin: 0 33%
+}
+
+.tippy-popper[x-placement^=top] [x-circle].enter {
+  -webkit-transform: scale(1) translate(-50%, -55%);
+  transform: scale(1) translate(-50%, -55%);
+  opacity: 1
+}
+
+.tippy-popper[x-placement^=top] [x-circle].leave {
+  -webkit-transform: scale(.15) translate(-50%, -50%);
+  transform: scale(.15) translate(-50%, -50%);
+  opacity: 0
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-circle] {
+  background-color: #fff
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow] {
+  border-top: 7px solid #fff;
+  border-right: 7px solid transparent;
+  border-left: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+  border-top: 5px solid #fff;
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+  border-top: 10px solid #fff;
+  border-right: 10px solid transparent;
+  border-left: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-circle] {
+  background-color: rgba(0, 0, 0, .7)
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow] {
+  border-top: 7px solid rgba(0, 0, 0, .7);
+  border-right: 7px solid transparent;
+  border-left: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+  border-top: 5px solid rgba(0, 0, 0, .7);
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+  border-top: 10px solid rgba(0, 0, 0, .7);
+  border-right: 10px solid transparent;
+  border-left: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=top] [data-animation=perspective] {
+  -webkit-transform-origin: bottom;
+  transform-origin: bottom
+}
+
+.tippy-popper[x-placement^=top] [data-animation=perspective].enter {
+  opacity: 1;
+  -webkit-transform: translateY(-10px) rotateX(0);
+  transform: translateY(-10px) rotateX(0)
+}
+
+.tippy-popper[x-placement^=top] [data-animation=perspective].leave {
+  opacity: 0;
+  -webkit-transform: translateY(0) rotateX(90deg);
+  transform: translateY(0) rotateX(90deg)
+}
+
+.tippy-popper[x-placement^=top] [data-animation=fade].enter {
+  opacity: 1;
+  -webkit-transform: translateY(-10px);
+  transform: translateY(-10px)
+}
+
+.tippy-popper[x-placement^=top] [data-animation=fade].leave {
+  opacity: 0;
+  -webkit-transform: translateY(-10px);
+  transform: translateY(-10px)
+}
+
+.tippy-popper[x-placement^=top] [data-animation=shift].enter {
+  opacity: 1;
+  -webkit-transform: translateY(-10px);
+  transform: translateY(-10px)
+}
+
+.tippy-popper[x-placement^=top] [data-animation=shift].leave {
+  opacity: 0;
+  -webkit-transform: translateY(0);
+  transform: translateY(0)
+}
+
+.tippy-popper[x-placement^=top] [data-animation=scale].enter {
+  opacity: 1;
+  -webkit-transform: translateY(-10px) scale(1);
+  transform: translateY(-10px) scale(1)
+}
+
+.tippy-popper[x-placement^=top] [data-animation=scale].leave {
+  opacity: 0;
+  -webkit-transform: translateY(0) scale(0);
+  transform: translateY(0) scale(0)
+}
+
+.tippy-popper[x-placement^=bottom] [x-arrow] {
+  border-bottom: 7px solid #333;
+  border-right: 7px solid transparent;
+  border-left: 7px solid transparent;
+  top: -7px;
+  margin: 0 9px
+}
+
+.tippy-popper[x-placement^=bottom] [x-arrow].arrow-small {
+  border-bottom: 5px solid #333;
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  top: -5px
+}
+
+.tippy-popper[x-placement^=bottom] [x-arrow].arrow-big {
+  border-bottom: 10px solid #333;
+  border-right: 10px solid transparent;
+  border-left: 10px solid transparent;
+  top: -10px
+}
+
+.tippy-popper[x-placement^=bottom] [x-circle] {
+  -webkit-transform-origin: 0 -50%;
+  transform-origin: 0 -50%
+}
+
+.tippy-popper[x-placement^=bottom] [x-circle].enter {
+  -webkit-transform: scale(1) translate(-50%, -45%);
+  transform: scale(1) translate(-50%, -45%);
+  opacity: 1
+}
+
+.tippy-popper[x-placement^=bottom] [x-circle].leave {
+  -webkit-transform: scale(.15) translate(-50%, -5%);
+  transform: scale(.15) translate(-50%, -5%);
+  opacity: 0
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-circle] {
+  background-color: #fff
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow] {
+  border-bottom: 7px solid #fff;
+  border-right: 7px solid transparent;
+  border-left: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+  border-bottom: 5px solid #fff;
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+  border-bottom: 10px solid #fff;
+  border-right: 10px solid transparent;
+  border-left: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-circle] {
+  background-color: rgba(0, 0, 0, .7)
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow] {
+  border-bottom: 7px solid rgba(0, 0, 0, .7);
+  border-right: 7px solid transparent;
+  border-left: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+  border-bottom: 5px solid rgba(0, 0, 0, .7);
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+  border-bottom: 10px solid rgba(0, 0, 0, .7);
+  border-right: 10px solid transparent;
+  border-left: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=perspective] {
+  -webkit-transform-origin: top;
+  transform-origin: top
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=perspective].enter {
+  opacity: 1;
+  -webkit-transform: translateY(10px) rotateX(0);
+  transform: translateY(10px) rotateX(0)
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=perspective].leave {
+  opacity: 0;
+  -webkit-transform: translateY(0) rotateX(-90deg);
+  transform: translateY(0) rotateX(-90deg)
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=fade].enter {
+  opacity: 1;
+  -webkit-transform: translateY(10px);
+  transform: translateY(10px)
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=fade].leave {
+  opacity: 0;
+  -webkit-transform: translateY(10px);
+  transform: translateY(10px)
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=shift].enter {
+  opacity: 1;
+  -webkit-transform: translateY(10px);
+  transform: translateY(10px)
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=shift].leave {
+  opacity: 0;
+  -webkit-transform: translateY(0);
+  transform: translateY(0)
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=scale].enter {
+  opacity: 1;
+  -webkit-transform: translateY(10px) scale(1);
+  transform: translateY(10px) scale(1)
+}
+
+.tippy-popper[x-placement^=bottom] [data-animation=scale].leave {
+  opacity: 0;
+  -webkit-transform: translateY(0) scale(0);
+  transform: translateY(0) scale(0)
+}
+
+.tippy-popper[x-placement^=left] [x-arrow] {
+  border-left: 7px solid #333;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  right: -7px;
+  margin: 6px 0
+}
+
+.tippy-popper[x-placement^=left] [x-arrow].arrow-small {
+  border-left: 5px solid #333;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  right: -5px
+}
+
+.tippy-popper[x-placement^=left] [x-arrow].arrow-big {
+  border-left: 10px solid #333;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  right: -10px
+}
+
+.tippy-popper[x-placement^=left] [x-circle] {
+  -webkit-transform-origin: 50% 0;
+  transform-origin: 50% 0
+}
+
+.tippy-popper[x-placement^=left] [x-circle].enter {
+  -webkit-transform: scale(1) translate(-50%, -50%);
+  transform: scale(1) translate(-50%, -50%);
+  opacity: 1
+}
+
+.tippy-popper[x-placement^=left] [x-circle].leave {
+  -webkit-transform: scale(.15) translate(-50%, -50%);
+  transform: scale(.15) translate(-50%, -50%);
+  opacity: 0
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-circle] {
+  background-color: #fff
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow] {
+  border-left: 7px solid #fff;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+  border-left: 5px solid #fff;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+  border-left: 10px solid #fff;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-circle] {
+  background-color: rgba(0, 0, 0, .7)
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow] {
+  border-left: 7px solid rgba(0, 0, 0, .7);
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+  border-left: 5px solid rgba(0, 0, 0, .7);
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+  border-left: 10px solid rgba(0, 0, 0, .7);
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=left] [data-animation=perspective] {
+  -webkit-transform-origin: right;
+  transform-origin: right
+}
+
+.tippy-popper[x-placement^=left] [data-animation=perspective].enter {
+  opacity: 1;
+  -webkit-transform: translateX(-10px) rotateY(0);
+  transform: translateX(-10px) rotateY(0)
+}
+
+.tippy-popper[x-placement^=left] [data-animation=perspective].leave {
+  opacity: 0;
+  -webkit-transform: translateX(0) rotateY(-90deg);
+  transform: translateX(0) rotateY(-90deg)
+}
+
+.tippy-popper[x-placement^=left] [data-animation=fade].enter {
+  opacity: 1;
+  -webkit-transform: translateX(-10px);
+  transform: translateX(-10px)
+}
+
+.tippy-popper[x-placement^=left] [data-animation=fade].leave {
+  opacity: 0;
+  -webkit-transform: translateX(-10px);
+  transform: translateX(-10px)
+}
+
+.tippy-popper[x-placement^=left] [data-animation=shift].enter {
+  opacity: 1;
+  -webkit-transform: translateX(-10px);
+  transform: translateX(-10px)
+}
+
+.tippy-popper[x-placement^=left] [data-animation=shift].leave {
+  opacity: 0;
+  -webkit-transform: translateX(0);
+  transform: translateX(0)
+}
+
+.tippy-popper[x-placement^=left] [data-animation=scale].enter {
+  opacity: 1;
+  -webkit-transform: translateX(-10px) scale(1);
+  transform: translateX(-10px) scale(1)
+}
+
+.tippy-popper[x-placement^=left] [data-animation=scale].leave {
+  opacity: 0;
+  -webkit-transform: translateX(0) scale(0);
+  transform: translateX(0) scale(0)
+}
+
+.tippy-popper[x-placement^=right] [x-arrow] {
+  border-right: 7px solid #333;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  left: -7px;
+  margin: 6px 0
+}
+
+.tippy-popper[x-placement^=right] [x-arrow].arrow-small {
+  border-right: 5px solid #333;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  left: -5px
+}
+
+.tippy-popper[x-placement^=right] [x-arrow].arrow-big {
+  border-right: 10px solid #333;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  left: -10px
+}
+
+.tippy-popper[x-placement^=right] [x-circle] {
+  -webkit-transform-origin: -50% 0;
+  transform-origin: -50% 0
+}
+
+.tippy-popper[x-placement^=right] [x-circle].enter {
+  -webkit-transform: scale(1) translate(-50%, -50%);
+  transform: scale(1) translate(-50%, -50%);
+  opacity: 1
+}
+
+.tippy-popper[x-placement^=right] [x-circle].leave {
+  -webkit-transform: scale(.15) translate(-50%, -50%);
+  transform: scale(.15) translate(-50%, -50%);
+  opacity: 0
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-circle] {
+  background-color: #fff
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow] {
+  border-right: 7px solid #fff;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+  border-right: 5px solid #fff;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+  border-right: 10px solid #fff;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-circle] {
+  background-color: rgba(0, 0, 0, .7)
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow] {
+  border-right: 7px solid rgba(0, 0, 0, .7);
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+  border-right: 5px solid rgba(0, 0, 0, .7);
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent
+}
+
+.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+  border-right: 10px solid rgba(0, 0, 0, .7);
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent
+}
+
+.tippy-popper[x-placement^=right] [data-animation=perspective] {
+  -webkit-transform-origin: left;
+  transform-origin: left
+}
+
+.tippy-popper[x-placement^=right] [data-animation=perspective].enter {
+  opacity: 1;
+  -webkit-transform: translateX(10px) rotateY(0);
+  transform: translateX(10px) rotateY(0)
+}
+
+.tippy-popper[x-placement^=right] [data-animation=perspective].leave {
+  opacity: 0;
+  -webkit-transform: translateX(0) rotateY(90deg);
+  transform: translateX(0) rotateY(90deg)
+}
+
+.tippy-popper[x-placement^=right] [data-animation=fade].enter {
+  opacity: 1;
+  -webkit-transform: translateX(10px);
+  transform: translateX(10px)
+}
+
+.tippy-popper[x-placement^=right] [data-animation=fade].leave {
+  opacity: 0;
+  -webkit-transform: translateX(10px);
+  transform: translateX(10px)
+}
+
+.tippy-popper[x-placement^=right] [data-animation=shift].enter {
+  opacity: 1;
+  -webkit-transform: translateX(10px);
+  transform: translateX(10px)
+}
+
+.tippy-popper[x-placement^=right] [data-animation=shift].leave {
+  opacity: 0;
+  -webkit-transform: translateX(0);
+  transform: translateX(0)
+}
+
+.tippy-popper[x-placement^=right] [data-animation=scale].enter {
+  opacity: 1;
+  -webkit-transform: translateX(10px) scale(1);
+  transform: translateX(10px) scale(1)
+}
+
+.tippy-popper[x-placement^=right] [data-animation=scale].leave {
+  opacity: 0;
+  -webkit-transform: translateX(0) scale(0);
+  transform: translateX(0) scale(0)
+}
+
+.tippy-popper .tippy-tooltip.transparent-theme {
+  background-color: rgba(0, 0, 0, .7)
+}
+
+.tippy-popper .tippy-tooltip.transparent-theme[data-animatefill] {
+  background-color: transparent
+}
+
+.tippy-popper .tippy-tooltip.light-theme {
+  color: #26323d;
+  box-shadow: 0 4px 20px 4px rgba(0, 20, 60, .1), 0 4px 80px -8px rgba(0, 20, 60, .2);
+  background-color: #fff
+}
+
+.tippy-popper .tippy-tooltip.light-theme[data-animatefill] {
+  background-color: transparent
+}
+
+.tippy-tooltip {
+  position: relative;
+  color: #fff;
+  border-radius: 4px;
+  font-size: .95rem;
+  padding: .4rem .8rem;
+  text-align: center;
+  will-change: transform;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-color: #333
+}
+
+.tippy-tooltip--small {
+  padding: .25rem .5rem;
+  font-size: .8rem
+}
+
+.tippy-tooltip--big {
+  padding: .6rem 1.2rem;
+  font-size: 1.2rem
+}
+
+.tippy-tooltip[data-animatefill] {
+  overflow: hidden;
+  background-color: transparent
+}
+
+.tippy-tooltip[data-interactive] {
+  pointer-events: auto
+}
+
+.tippy-tooltip[data-inertia] {
+  -webkit-transition-timing-function: cubic-bezier(.53, 1, .36, .85);
+  transition-timing-function: cubic-bezier(.53, 2, .36, .85)
+}
+
+.tippy-tooltip [x-arrow] {
+  position: absolute;
+  width: 0;
+  height: 0
+}
+
+.tippy-tooltip [x-circle] {
+  position: absolute;
+  will-change: transform;
+  background-color: #333;
+  border-radius: 50%;
+  width: 130%;
+  width: calc(110% + 2rem);
+  left: 50%;
+  top: 50%;
+  z-index: -1;
+  overflow: hidden;
+  -webkit-transition: all ease;
+  transition: all ease
+}
+
+.tippy-tooltip [x-circle]:before {
+  content: "";
+  padding-top: 90%;
+  float: left
+}
+
+@media (max-width:450px) {
+  .tippy-popper {
+      max-width: 96%;
+      max-width: calc(100% - 20px)
+  }
+}


### PR DESCRIPTION
- adds expand collapse cue for each node on hover.  
- uses tippy tooltips to implement the cue
- 'meta edges' from the expand collapse library are dashed to communicate that they are 'meta edges'
- many subtle complexities and edge cases are handled but there are probably more that I can't think of right now.

![screen shot 2018-07-31 at 10 28 40 am](https://user-images.githubusercontent.com/2328291/43466001-94f02ad4-94ac-11e8-8dbc-15b2c0ee4db0.png)
![screen shot 2018-07-31 at 10 28 30 am](https://user-images.githubusercontent.com/2328291/43466002-9501a8f4-94ac-11e8-8f94-a3375874550c.png)
![screen shot 2018-07-31 at 10 28 25 am](https://user-images.githubusercontent.com/2328291/43466003-951345be-94ac-11e8-808a-9a69886b2584.png)
