### PR TITLE
Jeff and Max : caching changes and misc. changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lint": "run-s lint:*",
     "watch": "run-p watch:*",
     "test": "mocha --recursive",
-    "test:travis": "run-s test lint"
+    "test:travis": "run-s test lint",
+    "ci": "run-s test lint"
   },
   "dependencies": {
     "body-parser": "^1.18.2",

--- a/src/client/features/enrichment-map/token-input.js
+++ b/src/client/features/enrichment-map/token-input.js
@@ -38,10 +38,7 @@ class TokenInput extends React.Component {
         genes: aliases,
         unrecognized: result.unrecognized,
       });
-    })
-    .catch(
-      error => error
-    );
+    });
   }
 
   render() {

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -33,10 +33,7 @@ class TokenInput extends React.Component {
       this.props.handleGenes( aliases );
       this.props.handleUnrecognized( result.unrecognized );
       this.props.handleInputs( this.state.inputBoxContents );
-    })
-    .catch(
-      error => error
-    );
+    });
   }
 
   render() {

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -77,11 +77,7 @@ const ServerAPI = {
       body: JSON.stringify(query),
       timeout: FETCH_TIMEOUT
     })
-    .then(res => res.json())
-    .catch(err => {
-      if (err.type == 'body-timeout') return undefined ;
-      else err;
-    });
+    .then(res => res.json());
   },
 
   geneQuery(query){

--- a/src/server/cache.js
+++ b/src/server/cache.js
@@ -1,4 +1,6 @@
 const hasher = require('node-object-hash')();
+const isPromise = p => p != null && p.then != null;
+const logger = require('./logger');
 
 const cache = (fn, cache) => {
   return function(){
@@ -10,6 +12,17 @@ const cache = (fn, cache) => {
       let res = fn.apply(null, arguments);
 
       cache.set(hash, res);
+
+      // for promises, delete the cache entry on errors
+      if(isPromise(res)){
+        res.catch(err => {
+          cache.del(hash);
+
+          logger.error(`A cache failed to be filled with args`);
+          logger.error(arguments);
+          logger.error(err);
+        });
+      }
 
       return res;
     }

--- a/src/server/enrichment/validation/index.js
+++ b/src/server/enrichment/validation/index.js
@@ -4,10 +4,8 @@ const { validOrganism } = require('./validity-info');
 const { validTargetDb } = require('./validity-info');
 const qs = require('query-string');
 const { cleanUpEntrez } = require('../helper');
-const logger = require('./../../logger');
 const config = require('../../../config');
 const GCONVERT_URL = config.GPROFILER_URL + 'gconvert.cgi';
-const FETCH_TIMEOUT = 5000; //ms
 const LRUCache = require('lru-cache');
 const cache = require('../../cache');
 const { PC_CACHE_MAX_SIZE } = require('../../../config');
@@ -93,22 +91,6 @@ const bodyHandler = body =>  {
   return resultTemplate( unrecognized, duplicate, geneInfo );
 };
 
-/* errorHandler
- * This function routes errors in a rational manner: Fetch-related errors are gently handled
- * by returning the original gene list as 'unrecognized'; For input errors, the Promise is
- * rejected with the error info for the client; in all other cases an Error is thrown.
- * @param { object } data - Error object and query (optional)
- * @return { Promise }
- */
-const errorHandler = ( error, query ) => {
-  logger.error( error );
-  switch ( error.name ) {
-    case 'FetchError':
-      return new Promise( resolve => resolve( resultTemplate( query ) ) );
-    default:
-      return new Promise( ( _, reject ) => reject( { "Error": error.message } ) );
-  }
-};
 
 
 /* rawValidatorGconvert
@@ -126,19 +108,17 @@ const rawValidatorGconvert = ( query, userOptions ) => {
   };
 
   return new Promise(( resolve, reject ) => {
-
     const form = getForm( query, defaultOptions, userOptions );
+
     fetch( GCONVERT_URL, {
         method: 'post',
-        body: qs.stringify( form ),
-        timeout: FETCH_TIMEOUT
+        body: qs.stringify( form )
     })
     .then( response => response.text() )
     .then( bodyHandler )
     .then( resolve )
     .catch( reject );
-  })
-  .catch( error => errorHandler( error, query ) );
+  });
 };
 
 const pcCache = LRUCache({ max: PC_CACHE_MAX_SIZE, length: () => 1 });


### PR DESCRIPTION
- Update package.json to have `npm run ci` shortcut so it's easy to run the CI tests locally before making a PR.
- Remove cases where promises have their error cases consumed without rethrowing.
- Revise the caching mechanism to selectively remove entries for failed promises.
- Remove enrichment server-side timeout and dummy data returned on failure case.

Supersedes #957

@d2fong Does this make sense with your enrichment-map=>enrichment changes?