### PR TITLE
Enrichment Style Changes after refactor

### DIFF
--- a/src/client/features/enrichment-map/index.js
+++ b/src/client/features/enrichment-map/index.js
@@ -24,9 +24,10 @@ class EnrichmentMap extends React.Component {
         nodes: [],
         edges: []
       },
-      activeMenu: 'enrichmentMenu',
+      activeMenu: 'closeMenu',
       loading: false,
-      invalidTokens: []
+      invalidTokens: [],
+      openToolBar: false
     };
 
     if( process.env.NODE_ENV !== 'production' ){
@@ -84,7 +85,9 @@ class EnrichmentMap extends React.Component {
       cy.layout(_.assign({}, ENRICHMENT_MAP_LAYOUT, { stop: () => {
         this.setState({
           loading: false,
+          activeMenu: 'enrichmentMenu',
           invalidTokens: unrecognized,
+          openToolBar: true
         });
       }})).run();
     };
@@ -94,7 +97,7 @@ class EnrichmentMap extends React.Component {
 
 
   render(){
-    let { loading, cySrv, enrichmentMap, activeMenu, invalidTokens } = this.state;
+    let { loading, cySrv, enrichmentMap, activeMenu, invalidTokens, openToolBar } = this.state;
 
     let network = h('div.network', { className: classNames({
       'network-loading': loading,
@@ -105,7 +108,7 @@ class EnrichmentMap extends React.Component {
       })
     ]);
 
-    let appBar = h('div.app-bar', [
+    let appBar = h('div.enrichment-app-bar', [
       h('div.app-bar-branding', [
         h('i.app-bar-logo', { href: 'http://www.pathwaycommons.org/' }),
         h('div.app-bar-title', 'Pathway Enrichment'),
@@ -113,7 +116,7 @@ class EnrichmentMap extends React.Component {
       ])
     ]);
 
-    let toolbar = h('div.app-toolbar', [
+    let toolbar = h('div.app-toolbar', {style: {display: openToolBar ? 'initial' : 'none'}}, [
       h(EnrichmentToolbar, { cySrv, activeMenu, controller: this })
     ]);
 
@@ -125,8 +128,8 @@ class EnrichmentMap extends React.Component {
     ]);
 
     return h('div.main', [
-        appBar,
         toolbar,
+        appBar,
         sidebar,
         h(Loader, { loaded: !loading, options: { left: '50%', color: '#16a085' }}, []),
         network

--- a/src/client/features/enrichment-map/index.js
+++ b/src/client/features/enrichment-map/index.js
@@ -109,14 +109,19 @@ class EnrichmentMap extends React.Component {
   render(){
     let { loading, cySrv, enrichmentMap, activeMenu, invalidTokens, openToolBar } = this.state;
 
-    let network = h('div.network', { className: classNames({
-      'network-loading': loading,
-      'network-sidebar-open': activeMenu !== 'closeMenu'
-    })}, [
-      h('div.network-cy', {
-        ref: dom => this.networkDiv = dom
-      })
-    ]);
+    let network = h('div.network', {
+        className: classNames({
+          'network-loading': loading,
+          'network-sidebar-open': activeMenu !== 'closeMenu'
+        }),
+        onClick: ()=> { document.getElementById('gene-input-box').blur(); }
+      },
+      [
+        h('div.network-cy', {
+          ref: dom => this.networkDiv = dom
+        })
+      ]
+    );
 
     let appBar = h('div.enrichment-app-bar', [
       h('div.app-bar-branding', [

--- a/src/client/features/enrichment-map/index.js
+++ b/src/client/features/enrichment-map/index.js
@@ -126,7 +126,7 @@ class EnrichmentMap extends React.Component {
       ])
     ]);
 
-    let toolbar = h('div.app-toolbar', {style: {display: openToolBar ? 'initial' : 'none'}}, [
+    let toolbar = h('div.enrichment-app-toolbar', {style: {display: openToolBar ? 'initial' : 'none'}}, [
       h(EnrichmentToolbar, { cySrv, activeMenu, controller: this })
     ]);
 
@@ -138,8 +138,10 @@ class EnrichmentMap extends React.Component {
     ]);
 
     return h('div.main', [
+      h('div', { className: classNames('menu-bar', { 'menu-bar-margin': activeMenu }) }, [
         toolbar,
-        appBar,
+        appBar
+      ]),
         sidebar,
         h(Loader, { loaded: !loading, options: { left: '50%', color: '#16a085' }}, []),
         network

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -1,25 +1,5 @@
 /*  ********ENRICHMENT INPUT BAR********   */
 
-.enrichment-icon {
-  background-image: url('../image/humanIcon.png');
-}
-
-.enrichment-app-bar {
-  max-width: 80vw;
-  position: absolute;
-  top: 0;
-  left: 30px;
-  background-color: var(--light-base-colour);
-  border: 1px solid var(--light-base-colour-dark);
-  padding: 4px 8px;
-  z-index: 10;
-}
-
-.enrichment-toolbar {
-  @extend %flex-center;
-  padding-top: 4px;
-}
-
 .enrichmentInput {
   display: flex;
   padding-left: 8px;
@@ -67,6 +47,24 @@
   border-radius: 0 !important;
   height: 1.85em;
   vertical-align: middle;
+}
+
+/*   ********ENRICHMENT TOOLBAR********  */
+
+.enrichment-app-bar {
+  padding: 4px 8px;
+  z-index: 10;
+}
+
+.enrichment-app-toolbar {
+  z-index: 10;
+  position: absolute;
+  top: 100%;
+  left: -1px;
+  border-style: solid;
+  border-width: 1px 1px 1px 1px;
+  border-radius: 0 0 0.25em 0.25em;
+  border-color: var(--light-base-colour-dark);
 }
 
 /*   ********ENRICHMENT SIDE MENU********  */

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -4,8 +4,25 @@
   background-image: url('../image/humanIcon.png');
 }
 
+.enrichment-app-bar {
+  max-width: 80vw;
+  position: absolute;
+  top: 0;
+  left: 30px;
+  background-color: var(--light-base-colour);
+  border: 1px solid var(--light-base-colour-dark);
+  padding: 4px 8px;
+  z-index: 10;
+}
+
+.enrichment-toolbar {
+  @extend %flex-center;
+  padding-top: 4px;
+}
+
 .enrichmentInput {
   display: flex;
+  padding-left: 8px;
 }
 
 .gene-input-container{

--- a/src/styles/features/pathways.css
+++ b/src/styles/features/pathways.css
@@ -10,8 +10,9 @@
   position: relative;
 }
 
-.pathways-toolbar { 
+.pathways-toolbar {
   @extend %flex-center;
+  height: 38px;
 }
 
 .pathways-search-nodes {


### PR DESCRIPTION
Changes for enrichment-map route

- fix styling for enrichment app after rerouting and refactoring
- off click input box to close 
- open toolbar and sidebar after an initial network has been loaded
- fix positioning of search box in toolbar
- app bar moves to the left if screen is width is decreased

Initial:
![image](https://user-images.githubusercontent.com/38890251/43856013-4f49f310-9b15-11e8-9914-b5afdbbee3d3.png)
After loading:
![image](https://user-images.githubusercontent.com/38890251/43856093-883ca64a-9b15-11e8-99ce-b4e94f6a555b.png)
