### PR TITLE
Make the interactions viewer button available when `NODE_ENV=development`

### DIFF
--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -37,7 +37,7 @@ class Interactions extends React.Component {
     super(props);
 
     const query = queryString.parse(props.location.search);
-    const sources = _.uniq(_.concat([],query.source)); //IDs or URIs
+    const sources = _.uniq(query.source.split(',')); //IDs or URIs
 
     this.state = {
       cySrv: new CytoscapeService({ style: interactionsStylesheet, showTooltipsOnEdges:true, minZoom:0.01 }),
@@ -45,7 +45,7 @@ class Interactions extends React.Component {
       layoutConfig: {},
       networkJSON: {},
       networkMetadata: {
-        name : sources+' Interactions',
+        name : sources.join(', ') + ' Interactions',
         datasource : 'Pathway Commons',
         comments: []
       },
@@ -87,7 +87,7 @@ class Interactions extends React.Component {
             node.addClass('hidden');
           i++;
         });
-    } 
+    }
 
       //for each filter (binding, phosphorylation, expression)
       //value: true/false

--- a/src/client/features/search/entity-info-box.js
+++ b/src/client/features/search/entity-info-box.js
@@ -2,6 +2,7 @@ const React = require('react');
 const h = require('react-hyperscript');
 const Link = require('react-router-dom').Link;
 const queryString = require('query-string');
+const NODE_ENV = process.env.NODE_ENV;
 
 const GENE_OTHER_NAMES_LIMIT = 4;
 const GENE_DESCRIPTION_WORD_LIMIT = 40;
@@ -70,13 +71,14 @@ class EntityInfoBoxList extends React.Component {
   render(){
     let { entityInfoList } = this.props;
 
-    let interactionsLinkQuery = ents => queryString.stringify({source: ents.map( ent => ent.officalSymbol )});
-    let viewMultipleInteractionsLink = (
+    let interactionsLinkQuery = ents => queryString.stringify({ source: ents.map( ent => ent.officialSymbol ).join(',') });
+
+    let viewMultipleInteractionsLink = () => (
       h(Link, {
           to: { pathname: '/interactions', search: interactionsLinkQuery(entityInfoList) },
           target: '_blank',
         }, [
-        h('button.search-landing-button', 'View Interactions Between Entities')
+        h('button.search-landing-button', 'Interactions Viewer (beta)')
       ])
     );
 
@@ -90,7 +92,8 @@ class EntityInfoBoxList extends React.Component {
 
 
     return h('div.entity-info-list', [
-      h('div.entity-info-list-entries', entityInfoBoxes)
+      h('div.entity-info-list-entries', entityInfoBoxes),
+      NODE_ENV !== 'production' && entityInfoList.length > 0 ? h(viewMultipleInteractionsLink) : null
     ]);
   }
 }


### PR DESCRIPTION
- Show the button to open the interactions viewer only when in dev mode (e.g. watch).
- Fix : Clean up the entity list sent through the URL: Just use a simple comma-separated string.

Note: The button would not be visible on appsbeta.pathwaycommons.org.  Another flag would be needed independent of dev/prod for that.  This should suffice for local development of the interactions viewer, and the flag check can be removed completely when it's ready to be released.