### PR TITLE
Empty string tooltip

### DIFF
--- a/src/client/features/paint/pathway-node-metadata.js
+++ b/src/client/features/paint/pathway-node-metadata.js
@@ -48,6 +48,7 @@ class PathwayNodeMetadataView extends React.Component {
 
     let showBody = showStdName || showDispName || showSynonyms || showPubs;
     let showLinks = metadata.databaseLinks().length > 0;
+    let showPcSearchLink = metadata.label() || metadata.displayName();
 
     return h('div.metadata-tooltip', [
       h('div.metadata-tooltip-content', [
@@ -90,14 +91,14 @@ class PathwayNodeMetadataView extends React.Component {
             }))
           ]) : null
         ]),
-        h('div.metadata-search-call-to-action', [
+        showPcSearchLink ? h('div.metadata-search-call-to-action', [
           h('a.metadata-find-pathways', {
             target: '_blank',
             href: '/search?q=' + metadata.searchLink()
             },
             `FIND RELATED PATHWAYS`
           )
-        ])
+        ]) : null
       ])
     ]);
   }

--- a/src/client/features/paint/pathway-node-metadata.js
+++ b/src/client/features/paint/pathway-node-metadata.js
@@ -52,7 +52,7 @@ class PathwayNodeMetadataView extends React.Component {
     return h('div.metadata-tooltip', [
       h('div.metadata-tooltip-content', [
         h('div.metadata-tooltip-header', [
-          h('h2',  `${metadata.label() || metadata.displayName() || 'Unknown Entity'}`),
+          h('h2',  `${metadata.label() || metadata.displayName() || ''}`),
           showType ? h('div.metadata-tooltip-type-chip', metadata.type()) : null,
         ]),
         showBody ? h('div.metadata-tooltip-body', [

--- a/src/client/features/pathways/index.js
+++ b/src/client/features/pathways/index.js
@@ -106,9 +106,7 @@ class Pathways extends React.Component {
     ]);
 
     let content = [
-      h(Loader, { loaded: !loading, options: { left: '50%', color: '#16a085' }}),
-      appBar,
-      toolbar,
+      h(Loader, { loaded: !loading, options: { left: '50%', color: '#16a085' }}, [ appBar, toolbar ]),
       sidebar,
       network,
     ];

--- a/src/client/features/pathways/pathway-node-metadata.js
+++ b/src/client/features/pathways/pathway-node-metadata.js
@@ -48,11 +48,12 @@ class PathwayNodeMetadataView extends React.Component {
 
     let showBody = showStdName || showDispName || showSynonyms || showPubs;
     let showLinks = metadata.databaseLinks().length > 0;
+    let showPcSearchLink = metadata.label() || metadata.displayName();
 
     return h('div.metadata-tooltip', [
       h('div.metadata-tooltip-content', [
         h('div.metadata-tooltip-header', [
-          h('h2',  `${metadata.label() || metadata.displayName() || 'Unknown Entity'}`),
+          h('h2',  `${metadata.label() || metadata.displayName() || ''}`),
           showType ? h('div.metadata-tooltip-type-chip', metadata.type()) : null,
         ]),
         showBody ? h('div.metadata-tooltip-body', [
@@ -90,14 +91,14 @@ class PathwayNodeMetadataView extends React.Component {
             }))
           ]) : null
         ]),
-        h('div.metadata-search-call-to-action', [
+        showPcSearchLink ? h('div.metadata-search-call-to-action', [
           h('a.metadata-find-pathways', {
             target: '_blank',
             href: '/search?q=' + metadata.searchLink()
             },
             `FIND RELATED PATHWAYS`
           )
-        ])
+        ]) : null
       ])
     ]);
   }


### PR DESCRIPTION
refs #961

Also refs another issue about not showing the pc search link button in the tooltip if the search query would be empty

Also refs another issue about not loading the appbar/toolbar if the pathway is not loaded yet.