### PR TITLE
Enrichment example input #1020

### DIFF
--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -21,8 +21,8 @@ class TokenInput extends React.Component {
 
   setExample() {
     let example = ['tyr', 'oca2', 'tyrp1', 'slc45a2'];
-    example = example.join(`\n`);
-    this.setState({ inputBoxContents: example });
+    this.setState({ inputBoxContents: example.join(`\n`) });
+    //open input box when example is inserted
     document.getElementById('gene-input-box').focus();
   }
 

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -19,6 +19,12 @@ class TokenInput extends React.Component {
     this.setState({inputBoxContents: e.target.value});
   }
 
+  setExample() {
+    const example = `tyr\noca2\ntyrp2\nslc45a2`;
+    this.setState({ inputBoxContents: example });
+    document.getElementById('gene-input-box').focus();
+  }
+
   //call validation service API to retrieve validation result in the form of []
   retrieveValidationAPIResult(){
     let { inputBoxContents } = this.state;
@@ -44,6 +50,9 @@ class TokenInput extends React.Component {
   render() {
     let { inputBoxContents } = this.state;
 
+    let exampleLink =  !inputBoxContents ? h('div.enrichment-example-container', {onClick: () => this.setExample()}, [
+    h('button.example', 'e.g. ')]) : null;
+
     return h('div.enrichmentInput', [
         h('div.gene-input-container', [
           h(Textarea, {
@@ -53,7 +62,9 @@ class TokenInput extends React.Component {
             value: inputBoxContents,
             spellCheck: false,
             onChange: (e) => this.handleChange(e)
-          })
+          }
+        ),
+          exampleLink
         ]),
         h('submit-container', {
           onClick: () => { this.retrieveValidationAPIResult();} },

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -20,7 +20,7 @@ class TokenInput extends React.Component {
   }
 
   setExample() {
-    const example = `tyr\noca2\ntyrp2\nslc45a2`;
+    const example = `tyr\noca2\ntyrp1\nslc45a2`;
     this.setState({ inputBoxContents: example });
     document.getElementById('gene-input-box').focus();
   }

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -20,7 +20,8 @@ class TokenInput extends React.Component {
   }
 
   setExample() {
-    const example = `tyr\noca2\ntyrp1\nslc45a2`;
+    let example = ['tyr', 'oca2', 'tyrp1', 'slc45a2'];
+    example = example.join(`\n`);
     this.setState({ inputBoxContents: example });
     document.getElementById('gene-input-box').focus();
   }

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -7,13 +7,13 @@
 
 .gene-input-container{
   height: 1.85em;
-  width: 200px;
+  width: 220px;
 }
 
 .gene-input-box{
   min-height: 1.85em;
   max-height: 80%;
-  width: 200px;
+  width: 220px;
   background-color: white;
   padding: 0em 0.5em;
   box-sizing: border-box;
@@ -36,10 +36,30 @@
   max-height: 1.85em;
 }
 
+.enrichment-example-container{
+  position: absolute;
+  box-sizing: border-box;
+  right: 75px;
+  border: 1px hidden;
+  height: 1.85em;
+  width:auto;
+  z-index: 20;
+  height: 1.85em;
+  top:inherit;
+
+  & button{
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    line-height: 1.8;
+    color: var(--dark-base-colour);
+    border: none;
+  }
+}
+
 /* submit button for gene input */
 .submit{
   background-color: var(--dark-base-colour);
-  /* background-color: #16A086; */
   color: white;
   font-weight: normal;
   border: 1px solid var(--light-base-colour-dark);

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -42,16 +42,12 @@
   box-sizing: border-box;
   margin-top: 1px;
   right: 0px;
-  height: 1.85em;
   width: 30px;
   z-index: 20;
-  top: inherit;
 
   & button{
-    margin: 0;
     padding: 0;
     border: none;
-    line-height: 1.8;
     color: var(--dark-base-colour);
   }
 

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -39,21 +39,20 @@
 .enrichment-example-container{
   position: absolute;
   box-sizing: border-box;
-  right: 75px;
-  border: 1px hidden;
+  right: 72px;
   height: 1.85em;
-  width:auto;
-  z-index: 20;
+  width: 30px;
+  z-index: 100;
   height: 1.85em;
-  top:inherit;
+  top: inherit;
 
   & button{
+    position: absolute;
     margin: 0;
     padding: 0;
-    height: 100%;
+    border:none;
     line-height: 1.8;
     color: var(--dark-base-colour);
-    border: none;
   }
 }
 

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -7,14 +7,14 @@
 
 .gene-input-container{
   height: 1.85em;
-  width: 220px;
+  width: 225px;
   position: relative;
 }
 
 .gene-input-box{
   min-height: 1.85em;
   max-height: 80%;
-  width: 220px;
+  width: 225px;
   background-color: white;
   padding: 0em 0.5em;
   box-sizing: border-box;

--- a/src/styles/features/enrichment.css
+++ b/src/styles/features/enrichment.css
@@ -8,6 +8,7 @@
 .gene-input-container{
   height: 1.85em;
   width: 220px;
+  position: relative;
 }
 
 .gene-input-box{
@@ -39,20 +40,23 @@
 .enrichment-example-container{
   position: absolute;
   box-sizing: border-box;
-  right: 72px;
+  margin-top: 1px;
+  right: 0px;
   height: 1.85em;
   width: 30px;
-  z-index: 100;
-  height: 1.85em;
+  z-index: 20;
   top: inherit;
 
   & button{
-    position: absolute;
     margin: 0;
     padding: 0;
-    border:none;
+    border: none;
     line-height: 1.8;
     color: var(--dark-base-colour);
+  }
+
+  & button:hover{
+    color:#16a085;
   }
 }
 


### PR DESCRIPTION
- example input for enrichment set to: "tyr, oca2, tyrp1, slc45a2"  
(chosen because of quick loading time and variation in node sizes and colours)

- text colour change on hover 'e.g.' 
- 'e.g.' disappears once any text is typed into input box
- input box opens when example input is selected



![image](https://user-images.githubusercontent.com/38890251/44283817-901f5280-a22d-11e8-95b4-b0392723d69a.png)
![image](https://user-images.githubusercontent.com/38890251/44283824-93b2d980-a22d-11e8-9ef7-09df75e439a9.png)
Resulting Network
![image](https://user-images.githubusercontent.com/38890251/44283832-97def700-a22d-11e8-8c65-eed690b0b9f6.png)
