### PR TITLE
hide 'close sidebar' button #1024

### DIFF
--- a/src/styles/features/pathways/sidebar-menu.css
+++ b/src/styles/features/pathways/sidebar-menu.css
@@ -11,6 +11,7 @@
   box-shadow: 0;
   opacity: 0;
   transform: translate3d(110%, 0, 0);
+  pointer-events: none;
   transition-duration: 250ms;
   transition-property: transform, opacity;
   box-sizing: border-box;
@@ -20,6 +21,7 @@
   &.sidebar-menu-open {
     opacity: 1;
     transform: translate3d(0, 0, 0);
+    pointer-events: auto;
   }
 
   & a {

--- a/src/styles/features/pathways/sidebar-menu.css
+++ b/src/styles/features/pathways/sidebar-menu.css
@@ -10,7 +10,7 @@
   z-index: 25;
   box-shadow: 0;
   opacity: 0;
-  transform: translate3d(100%, 0, 0);
+  transform: translate3d(110%, 0, 0);
   transition-duration: 250ms;
   transition-property: transform, opacity;
   box-sizing: border-box;
@@ -45,6 +45,12 @@
   border-radius: 0 0 0 3px;
   border: 1px solid rgb(211, 216, 218);
   border-right: 0;
+  &.sidebar-menu-ope {
+    opacity: 0;
+    background-color: purple;
+    color:red !important;
+    /* transform: translate3d(0, 0, 0); */
+  }
 }
 
 .sidebar-content {

--- a/src/styles/features/pathways/sidebar-menu.css
+++ b/src/styles/features/pathways/sidebar-menu.css
@@ -9,8 +9,8 @@
   right: 0;
   z-index: 25;
   box-shadow: 0;
-  opacity: 1;
-  transform: translate3d(100%, 0, 0);
+  opacity: 0;
+  transform: translate3d(110%, 0, 0);
   transition-duration: 250ms;
   transition-property: transform, opacity;
   box-sizing: border-box;

--- a/src/styles/features/pathways/sidebar-menu.css
+++ b/src/styles/features/pathways/sidebar-menu.css
@@ -9,8 +9,8 @@
   right: 0;
   z-index: 25;
   box-shadow: 0;
-  opacity: 0;
-  transform: translate3d(110%, 0, 0);
+  opacity: 1;
+  transform: translate3d(100%, 0, 0);
   transition-duration: 250ms;
   transition-property: transform, opacity;
   box-sizing: border-box;
@@ -45,12 +45,6 @@
   border-radius: 0 0 0 3px;
   border: 1px solid rgb(211, 216, 218);
   border-right: 0;
-  &.sidebar-menu-ope {
-    opacity: 0;
-    background-color: purple;
-    color:red !important;
-    /* transform: translate3d(0, 0, 0); */
-  }
 }
 
 .sidebar-content {


### PR DESCRIPTION
#1024

- on close, slide the sidebar further to the right to fully hide it
- now if you hover in right corner, nothing shows up

Previously, not all of the sidebar was being hidden, it was just made to be opaque.
Previous view when opacity changed to '1' : 
![image](https://user-images.githubusercontent.com/38890251/44285972-54888680-a235-11e8-8fb2-34d21ef2b74f.png)

