### PR TITLE
use loading spinner and fit network to screen #1027

### DIFF
--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -124,7 +124,7 @@ class Enrichment extends React.Component {
     let network = h('div.network', {
         className: classNames({
           'network-loading': loading,
-          'network-sidebar-open': activeMenu !== 'closeMenu'
+          'network-sidebar-open': true
         }),
         onClick: ()=> { document.getElementById('gene-input-box').blur(); }
       },
@@ -159,9 +159,10 @@ class Enrichment extends React.Component {
         toolbar,
         appBar
       ]),
-        sidebar,
-        networkEmpty ? h(EmptyNetwork, { msg: 'No results to display', showPcLink: false} ) : null,
-        network
+      h(Loader, { loaded: !loading, options: { left: '50%', color: '#16a085' }}),
+      sidebar,
+      networkEmpty ? h(EmptyNetwork, { msg: 'No results to display', showPcLink: false} ) : null,
+      network
     ]);
   }
 }


### PR DESCRIPTION
Enrichment App
- use loading spinner
- fit loaded network to available space on screen
- hard code 'network-sidebar-open' to true since side menu will always be open when a network is loaded and a layout is applied. Before, value of 'false' was being passed when loading the network because of (activeMenu: 'closeMenu') in the constructor 