### PR TITLE
Match enrichment slider position on show/hide button clicked

### DIFF
--- a/src/client/features/enrichment/enrichment-menu.js
+++ b/src/client/features/enrichment/enrichment-menu.js
@@ -26,14 +26,14 @@ class EnrichmentMenu extends React.Component {
 
   render(){
 
-    let { invalidTokens, controller } = this.props;
+    let { invalidTokens, sliderVal } = this.props;
 
     const slider = [
-      h("input",{type:"range",id:'enrichment-p_value-slider',min:0,max:0.05,step:0.0001,defaultValue:controller.sliderVal,
+      h("input",{type:"range",id:'enrichment-p_value-slider',min:0,max:0.05,step:0.0001,defaultValue:sliderVal,
       onInput:() => this.sliderUpdate() })
     ];
 
-    this.filterNodes(controller.sliderVal);
+    this.filterNodes(sliderVal);
 
     const unrecognizedTokens = invalidTokens.length === 0 ? '' : [
         h('h3', 'Unrecognized Genes (' + invalidTokens.length + ')'),

--- a/src/client/features/enrichment/enrichment-menu.js
+++ b/src/client/features/enrichment/enrichment-menu.js
@@ -7,12 +7,15 @@ class EnrichmentMenu extends React.Component {
    *  @description Hides nodes based on adjusted p_value, determined by on-screen slider
    */
   sliderUpdate(){
-    const cy = this.props.cySrv.get();
-
     //get value from slider
     let sliderVal = document.getElementById('enrichment-p_value-slider').value;
+    this.props.controller.updateSlider(sliderVal);
+    this.filterNodes(sliderVal);
+  }
 
+  filterNodes(sliderVal){
     //compare p_values and hide if outside of chosen threshold
+    const cy = this.props.cySrv.get();
     cy.nodes().forEach(node => {
       if(node.data('p_value') > sliderVal)
         node.addClass('hidden');
@@ -23,17 +26,14 @@ class EnrichmentMenu extends React.Component {
 
   render(){
 
-    let { invalidTokens } = this.props;
+    let { invalidTokens, controller } = this.props;
 
     const slider = [
-      h("input",{type:"range",id:'enrichment-p_value-slider',min:0,max:0.05,step:0.0001,defaultValue:0.05,
+      h("input",{type:"range",id:'enrichment-p_value-slider',min:0,max:0.05,step:0.0001,defaultValue:controller.sliderVal,
       onInput:() => this.sliderUpdate() })
     ];
 
-    //when rendered all nodes show
-    this.props.cySrv.loadPromise().then((cy) => {
-      cy.batch(()=>{cy.elements().removeClass('hidden');});
-      });
+    this.filterNodes(controller.sliderVal);
 
     const unrecognizedTokens = invalidTokens.length === 0 ? '' : [
         h('h3', 'Unrecognized Genes (' + invalidTokens.length + ')'),

--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -32,6 +32,8 @@ class Enrichment extends React.Component {
       networkEmpty: false
     };
 
+    this.sliderVal = 0.05;
+
     if( process.env.NODE_ENV !== 'production' ){
       this.state.cySrv.getPromise().then(cy => window.cy = cy);
     }
@@ -117,6 +119,10 @@ class Enrichment extends React.Component {
     this.setState({ loading: true, activeMenu: 'closeMenu', openToolBar: false, networkEmpty: false }, () => updateNetworkJSON());
   }
 
+  updateSlider( sliderVal ){
+    this.sliderVal = sliderVal;
+  }
+
 
   render(){
     let { loading, cySrv, activeMenu, invalidTokens, openToolBar, networkEmpty } = this.state;
@@ -148,7 +154,7 @@ class Enrichment extends React.Component {
 
     let sidebar = h('div.enrichment-sidebar', [
       h(Sidebar, { controller: this, activeMenu }, [
-        h(EnrichmentMenu, { key: 'enrichmentMenu', cySrv, invalidTokens }),
+        h(EnrichmentMenu, { key: 'enrichmentMenu', cySrv, invalidTokens, controller: this }),
         h(EnrichmentDownloadMenu, { key: 'enrichmentDownloadMenu', cySrv })
       ])
     ]);

--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -29,10 +29,9 @@ class Enrichment extends React.Component {
       loading: false,
       invalidTokens: [],
       openToolBar: false,
-      networkEmpty: false
+      networkEmpty: false,
+      sliderVal: 0.05
     };
-
-    this.sliderVal = 0.05;
 
     if( process.env.NODE_ENV !== 'production' ){
       this.state.cySrv.getPromise().then(cy => window.cy = cy);
@@ -120,12 +119,12 @@ class Enrichment extends React.Component {
   }
 
   updateSlider( sliderVal ){
-    this.sliderVal = sliderVal;
+    this.setState({ sliderVal: sliderVal });
   }
 
 
   render(){
-    let { loading, cySrv, activeMenu, invalidTokens, openToolBar, networkEmpty } = this.state;
+    let { loading, cySrv, activeMenu, invalidTokens, openToolBar, networkEmpty, sliderVal } = this.state;
 
     let network = h('div.network', {
         className: classNames({
@@ -154,7 +153,7 @@ class Enrichment extends React.Component {
 
     let sidebar = h('div.enrichment-sidebar', [
       h(Sidebar, { controller: this, activeMenu }, [
-        h(EnrichmentMenu, { key: 'enrichmentMenu', cySrv, invalidTokens, controller: this }),
+        h(EnrichmentMenu, { key: 'enrichmentMenu', cySrv, invalidTokens, controller: this, sliderVal: sliderVal }),
         h(EnrichmentDownloadMenu, { key: 'enrichmentDownloadMenu', cySrv })
       ])
     ]);


### PR DESCRIPTION
Refs: #984 

- Store slider value in main component
- When show/hide side menu button is clicked, the network will not reload
- Slider value matches its position.