### PR TITLE
index.html uses root path to get css/js bundles

### DIFF
--- a/src/client/router.js
+++ b/src/client/router.js
@@ -1,4 +1,4 @@
-const {BrowserRouter, Route} = require('react-router-dom');
+const {BrowserRouter, Route, Switch} = require('react-router-dom');
 const h = require('react-hyperscript');
 const ReactGA = require('react-ga');
 const _ = require('lodash');
@@ -6,53 +6,72 @@ const _ = require('lodash');
 const Features = require('./features');
 
 ReactGA.initialize('UA-43341809-7');
-const Analytics = (props) => {
-  ReactGA.set({ page: props.location.pathname + props.location.search });
-  ReactGA.pageview(props.location.pathname + props.location.search);
-  return null;
+let logPageView = page => {
+  ReactGA.set({ page });
+  ReactGA.pageview( page );
 };
 
 
 module.exports = () => {
   return h(BrowserRouter, [
-    h('div', [
-      {
-        path: '*',
-        render: props => h(Analytics, props)
-      },
+    h(Switch, [
       {
         path: '/',
-        render: props => h(Features.Search, props)
+        render: props => {
+          let { location } = props;
+          let { pathname, search } = location;
+          logPageView(pathname + search);
+          return h(Features.Search, props);
+        }
       },
       {
         path: '/search',
-        render: props => h(Features.Search, props)
+        render: props => {
+          let { location } = props;
+          let { pathname, search } = location;
+          logPageView(pathname + search);
+          return h(Features.Search, props);
+        }
       },
       {
         path: '/pathways',
-        render: props => h(Features.Pathways, props)
+        render: props => {
+          let { location } = props;
+          let { pathname, search } = location;
+          logPageView(pathname + search);
+          return h(Features.Pathways, props);
+        }
       },
       {
         path: '/paint',
-        render: props => h(Features.Paint, props)
+        render: props => {
+          let { location } = props;
+          let { pathname, search } = location;
+          logPageView(pathname + search);
+          return h(Features.Paint, props);
+        }
       },
       {
         path: '/interactions',
         render: props => {
+          let { location } = props;
+          let { pathname, search } = location;
+          logPageView(pathname + search);
           return h(Features.Interactions, props);
         }
       },
       {
         path: '/enrichment',
         render: props => {
+          let { location } = props;
+          let { pathname, search } = location;
+          logPageView(pathname + search);
           return h(Features.Enrichment, props);
         }
       },
       {
-        path: '/enrichment-map',
-        render: props => {
-          return h(Features.EnrichmentMap, props);
-        }
+        path: '*',
+        render: () => h('div', 'Page Not Found')
       }
     ].map( spec => h(Route, _.assign({ exact: true }, spec)) ))
   ]);

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -7,11 +7,11 @@
     <meta name="description" content="" />
     <meta name="keywords" content="" />
 
-    <link type="text/css" rel="stylesheet" href="deps.css" />
-    <link type="text/css" rel="stylesheet" href="bundle.css" />
+    <link type="text/css" rel="stylesheet" href="/deps.css" />
+    <link type="text/css" rel="stylesheet" href="/bundle.css" />
 
-    <script defer src="deps.js"></script>
-    <script defer src="bundle.js"></script>
+    <script defer src="/deps.js"></script>
+    <script defer src="/bundle.js"></script>
 
     <title>Pathway Commons</title>
   </head>


### PR DESCRIPTION
refs #1043

Currently, all non-api routes render index.html.  The problem when rendering index.html was that the corresponding js and css assets were specified as a relative path.  Leading to the browser trying to get assets like /search/bundle.js when the specified path was /search/.  These assets would not be found leading to the broken behaviour.  

This fix changes the path of the required assets in index.html