### PR TITLE
create cytoscape network component

### DIFF
--- a/src/client/common/components/cytoscape-network.js
+++ b/src/client/common/components/cytoscape-network.js
@@ -1,0 +1,30 @@
+const React = require('react');
+const h = require('react-hyperscript');
+const classNames = require('classnames');
+
+
+
+
+class CytoscapeNetwork extends React.Component {
+
+  componentDidMount(){
+    let { cySrv, onMount = () => {} } = this.props;
+    cySrv.mount(this.network);
+
+    onMount();
+  }
+  componentWillUnmount(){
+    let { cySrv } = this.props;
+    cySrv.destroy();
+  }
+
+  render(){
+    return h('div.network', { className: classNames('network', this.props.className)}, [
+      h('div.network-cy', {
+        ref: dom => this.network = dom
+      })
+    ]);
+  }
+}
+
+module.exports = CytoscapeNetwork;

--- a/src/client/features/enrichment/index.js
+++ b/src/client/features/enrichment/index.js
@@ -10,7 +10,7 @@ const EnrichmentMenu = require('./enrichment-menu');
 const TokenInput = require('./token-input');
 const EmptyNetwork = require('../../common/components/empty-network');
 const PcLogoLink = require('../../common/components/pc-logo-link');
-
+const CytoscapeNetwork = require('../../common/components/cytoscape-network');
 
 const CytoscapeService = require('../../common/cy/');
 const { ServerAPI } = require('../../services');
@@ -38,17 +38,6 @@ class Enrichment extends React.Component {
     if( process.env.NODE_ENV !== 'production' ){
       this.state.cySrv.getPromise().then(cy => window.cy = cy);
     }
-  }
-
-  componentDidMount(){
-    let { cySrv } = this.state;
-
-    cySrv.mount(this.networkDiv);
-    cySrv.load();
-  }
-
-  componentWillUnmount(){
-    this.state.cySrv.destroy();
   }
 
   changeMenu( menu, cb){
@@ -148,17 +137,13 @@ class Enrichment extends React.Component {
         ])
        ]),
       networkEmpty ? h(EmptyNetwork, { msg: 'No results to display', showPcLink: false} ) : null,
-      h('div.network', {
+      h(CytoscapeNetwork, {
+        cySrv,
         className: classNames({
-          'network-loading': loading,
-          'network-sidebar-open': activeMenu !== 'closeMenu'
-        }),
-        onClick: ()=> { document.getElementById('gene-input-box').blur(); }
-      }, [
-        h('div.network-cy', {
-          ref: dom => this.networkDiv = dom
+        'network-loading': loading,
+        'network-sidebar-open': activeMenu !== 'closeMenu'
         })
-      ])
+      })
     ]);
   }
 }

--- a/src/client/features/interactions/index.js
+++ b/src/client/features/interactions/index.js
@@ -12,6 +12,7 @@ const InteractionsToolbar = require('./interactions-toolbar');
 const Sidebar = require('../../common/components/sidebar');
 const EmptyNetwork = require('../../common/components/empty-network');
 const PcLogoLink = require('../../common/components/pc-logo-link');
+const CytoscapeNetwork = require('../../common/components/cytoscape-network');
 
 const { interactionsStylesheet, INTERACTIONS_LAYOUT_OPTS, bindEvents } = require('./cy');
 
@@ -35,11 +36,9 @@ class Interactions extends React.Component {
     }
   }
 
-  componentDidMount(){
+  loadInteractionsNetwork(){
     let { cySrv, sources } = this.state;
-
     let initializeCytoscape = network => {
-      cySrv.mount(this.networkDiv);
 
       let cy = cySrv.get();
       cy.remove('*');
@@ -56,7 +55,6 @@ class Interactions extends React.Component {
 
       cy.layout(_.assign({}, INTERACTIONS_LAYOUT_OPTS, {
         stop: () => {
-          cySrv.load();
           this.setState({
             loading: false,
           });
@@ -68,7 +66,6 @@ class Interactions extends React.Component {
     //   cy.nodes().filter( n => !n.hasClass('hidden') ).layout(_.assign({}, INTERACTIONS_LAYOUT_OPTS, {
     //     name: 'grid',
     //     stop: () => {
-    //       cySrv.load();
     //       this.setState({
     //         source,
     //         loading: false,
@@ -98,16 +95,6 @@ class Interactions extends React.Component {
 
   render() {
     let { loading, cySrv, activeMenu, sources, networkEmpty } = this.state;
-
-    let network = h('div.network', { className: classNames({
-      'network-loading': loading,
-      'network-sidebar-open': activeMenu !== 'closeMenu'
-    })}, [
-      h('div.network-cy', {
-        ref: dom => this.networkDiv = dom
-      })
-    ]);
-
     let appBar = h('div.app-bar', [
       h('div.app-bar-branding', [
         h(PcLogoLink),
@@ -126,7 +113,14 @@ class Interactions extends React.Component {
         appBar,
         sidebar
       ]),
-      network,
+      h(CytoscapeNetwork, {
+        cySrv,
+        onMount: () => this.loadInteractionsNetwork(),
+        className: classNames({
+        'network-loading': loading,
+        'network-sidebar-open': activeMenu !== 'closeMenu'
+        })
+      })
     ] : [ h(EmptyNetwork, { msg: 'No interactions to display', showPcLink: true} ) ];
 
 

--- a/src/client/features/paint/index.js
+++ b/src/client/features/paint/index.js
@@ -16,6 +16,7 @@ const InfoMenu = require('./menus/network-info-menu');
 const PaintMenu = require('./menus/paint-menu');
 const Sidebar = require('../../common/components/sidebar');
 const PcLogoLink = require('../../common/components/pc-logo-link');
+const CytoscapeNetwork = require('../../common/components/cytoscape-network');
 const PathwaysToolbar = require('./pathways-toolbar');
 
 const demoExpressions = require('./demo-expressions.json');
@@ -95,13 +96,13 @@ class Paint extends React.Component {
     }, () => this.loadPathway(pathways[0]));
   }
 
-  componentDidMount(){
+  // onMount prop passed to CytoscapeNetwork
+  // called after CytoscapeNetwork has mounted
+  getEnrichmentsAndPathways(){
     let query = queryString.parse(this.props.location.search);
     let searchParam = query.q;
     let enrichmentsUri = query.uri;
-    let { cySrv, expressionTable, paintMenuCtrls  } = this.state;
-    cySrv.mount(this.network);
-    cySrv.load();
+    let { expressionTable, paintMenuCtrls  } = this.state;
 
     // if the user just comes into the app without enrichments, load the demo data
     if( enrichmentsUri == null ){
@@ -197,25 +198,12 @@ class Paint extends React.Component {
     });
   }
 
-  componentWillUnmount(){
-    this.state.cySrv.destroy();
-  }
-
   render() {
     let { invalidEnrichments, loading, expressionTable, curPathway, pathways, cySrv, activeMenu, paintMenuCtrls, activeTab } = this.state;
 
     if( invalidEnrichments ){
       return h('div', 'The painter app requires enrichments that have an associated class file');
     }
-
-    let network = h('div.network', { className: classNames({
-      'network-loading': loading,
-      'network-sidebar-open': activeMenu !== 'closeMenu'
-    })}, [
-      h('div.network-cy', {
-        ref: dom => this.network = dom
-      })
-    ]);
 
     let appBar = h('div.app-bar', [
       h('div.app-bar-branding', [
@@ -250,7 +238,14 @@ class Paint extends React.Component {
 
     let content = [
       h(Loader, { loaded: !loading, options: { left: '50%', color: '#16a085' }}, [ appBar, sidebar ] ),
-      network,
+      h(CytoscapeNetwork, {
+        cySrv,
+        onMount: () => this.getEnrichmentsAndPathways(),
+        className: classNames({
+        'network-loading': loading,
+        'network-sidebar-open': activeMenu !== 'closeMenu'
+        })
+      })
     ];
 
     return h('div.pathways', content);


### PR DESCRIPTION
- create a cytoscape network component that handles componentWillMount/unMount logic.  
- parent components pass a 'onMount' prop that is called after the network component mounts
- the onMount prop is usually a server call to get some cytoscape json which is then loaded into cytoscape

@maxkfranz thoughts on this?