### PR TITLE
Make the SIF viewer link similar to all the other viewer links

### DIFF
--- a/src/client/features/search/entity-info-box.js
+++ b/src/client/features/search/entity-info-box.js
@@ -88,7 +88,7 @@ class EntityInfoBoxList extends React.Component {
         return `Interactions with ${sources[0]}`;
       }
 
-      return `Interactions between ${ sources.slice(0, sources.length - 1).join(', ') }, and ${sources.slice(-1)}`;
+      return `Interactions between ${ sources.slice(0, sources.length - 1).join(', ') + (sources.length > 2 ? ',' : '') } and ${sources.slice(-1)}`;
     };
 
     let ViewMultipleInteractionsEntry = () => {

--- a/src/client/features/search/entity-info-box.js
+++ b/src/client/features/search/entity-info-box.js
@@ -85,20 +85,27 @@ class EntityInfoBoxList extends React.Component {
 
     let interactionsLinkLabel = sources => {
       if( sources.length === 1 ){
-        return `View ${sources[0]} interactions`;
+        return `Interactions with ${sources[0]}`;
       }
 
-      return `View interactions between ${ sources.slice(0, sources.length - 1).join(', ') } and ${sources.slice(-1)}`;
+      return `Interactions between ${ sources.slice(0, sources.length - 1).join(', ') }, and ${sources.slice(-1)}`;
     };
 
-    let viewMultipleInteractionsLink = () => (
-        h(Link, {
-          to: { pathname: '/interactions', search: interactionsLinkQuery(entityInfoList) },
-          target: '_blank',
-        }, [
-          h('button.call-to-action', interactionsLinkLabel(entityInfoList.map( ent => ent.officialSymbol )))
-        ])
-    );
+    let ViewMultipleInteractionsEntry = () => {
+      return h('div.search-item', [
+        h('div.search-item-icon',[
+           h('img', { src: '/img/icon.png' })
+         ]),
+         h('div.search-item-content', [
+           h(Link, {
+             className: 'plain-link',
+             to: { pathname: '/interactions', search: interactionsLinkQuery(entityInfoList) },
+             target: '_blank'
+            }, interactionsLinkLabel(entityInfoList.map( ent => ent.officialSymbol ))),
+           h('p.search-item-content-datasource', 'Pathway Commons')
+         ])
+       ]);
+    };
 
     let entityInfoBoxes = entityInfoList.slice(0, GENE_INFO_DISPLAY_LIMIT).map( (entity, index) => {
       let props = { entity };
@@ -112,7 +119,7 @@ class EntityInfoBoxList extends React.Component {
     return h('div.entity-info-list', [
       h('div.entity-info-list-entries', entityInfoBoxes),
       entityInfoList.length != 0 ? h('div.entity-info-view-interactions', [
-        h(viewMultipleInteractionsLink)
+        h(ViewMultipleInteractionsEntry)
        ]) : null
     ]);
   }

--- a/src/styles/features/entity-landing-box.css
+++ b/src/styles/features/entity-landing-box.css
@@ -2,7 +2,10 @@
   max-width: var(--search-width);
   width: 100%;
   margin-top: 20px;
-  padding-bottom: 40px;
+}
+
+.entity-info-list-entries {
+  margin-bottom: 1.5em;
 }
 
 .entity-info-box {
@@ -87,7 +90,5 @@
 }
 
 .entity-info-view-interactions {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
+
 }


### PR DESCRIPTION
Since it looks like a normal search result, the user may be more likely to click it.

Preview:

![screen shot 2018-09-17 at 12 40 56 pm](https://user-images.githubusercontent.com/989043/45637057-816bcb80-ba77-11e8-9382-146754d084a1.png)

![screen shot 2018-09-17 at 12 47 30 pm](https://user-images.githubusercontent.com/989043/45637188-dad3fa80-ba77-11e8-8673-ea655c7ed9bc.png)


![screen shot 2018-09-17 at 12 47 07 pm](https://user-images.githubusercontent.com/989043/45637178-d1e32900-ba77-11e8-9aed-60f7c777deb6.png)
