### PR TITLE
Iss1103 part b: validation api

### DIFF
--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -42,13 +42,11 @@ class TokenInput extends React.Component {
        targetDb: "HGNCSYMBOL"
       }, "validation")
     .then( result => {
-      const aliases = result.geneInfo.map( value => {
-        return value.convertedAlias;
-      });
+      let { unrecognized, alias } = result;
 
       controller.handleGeneQueryResult( {
-        genes: aliases,
-        unrecognized: result.unrecognized,
+        genes: _.values( alias ),
+        unrecognized: unrecognized,
       });
     });
   }

--- a/src/client/features/search/query-entity-info.js
+++ b/src/client/features/search/query-entity-info.js
@@ -261,23 +261,18 @@ const queryEntityInfo = query => {
    let dbsToQuery = Object.entries(dbInfos).map( dbInfo => dbInfo[1] );
 
    // create entity recognizer queries
+   //This is temp fix for updated backend; super-complicated code will go away in move to server...
    entityQueries = dbsToQuery.map( db => {
      return ServerAPI.geneQuery({
        query: genes,
        targetDb: db.gProfiler
      }).then(res => {
-       let { geneInfo: entityInfos, unrecognized: unrecognizedEntities } = res;
-       let duplicates = new Set();
-       let entities = { unrecognizedEntities };
-
-       entityInfos.forEach( entityInfo => {
-         let { convertedAlias } = entityInfo;
-         if( !duplicates.has( convertedAlias ) ){
-           entities[ entityInfo.initialAlias ] = { [db.name]: convertedAlias };
-           duplicates.add( convertedAlias );
-         }
+       let { alias } = res;
+       let entities = {};
+       const initialAliases = _.keys( alias );
+       initialAliases.forEach( ia => {
+        entities[ ia ] = { [db.name]: alias[ia] };
        });
-
        return entities;
      });
    });

--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -13,11 +13,11 @@ const cache = require('../../../cache');
 const GCONVERT_URL = GPROFILER_URL + 'gconvert.cgi';
 
 
-const resultTemplate = ( unrecognized, duplicate, geneInfo ) => {
+const resultTemplate = ( unrecognized, duplicate, alias ) => {
   return {
     unrecognized: Array.from( unrecognized ) || [],
     duplicate: duplicate || {},
-    geneInfo: geneInfo || []
+    alias: alias || {}
   };
 };
 
@@ -61,15 +61,15 @@ const getForm = ( query, defaultOptions, userOptions ) => {
 };
 
 const bodyHandler = body =>  {
-  const geneInfoList = _.map(body.split('\n'), ele => { return ele.split('\t'); });
-  geneInfoList.splice(-1, 1); // remove last element ''
+  const entityInfoList = _.map(body.split('\n'), ele => { return ele.split('\t'); });
+  entityInfoList.splice(-1, 1); // remove last element ''
   const unrecognized = new Set();
   let duplicate = {};
   const previous = new Map();
-  let geneInfo = new Set();
+  let alias = {};
   const initialAliasIndex = 1;
   const convertedAliasIndex = 3;
-  _.forEach(geneInfoList, info => {
+  _.forEach(entityInfoList, info => {
     const convertedAlias = info[convertedAliasIndex];
     let initialAlias = info[initialAliasIndex];
     initialAlias = cleanUpEntrez(initialAlias);
@@ -84,14 +84,13 @@ const bodyHandler = body =>  {
         }
         duplicate[convertedAlias].add(initialAlias);
       }
-      geneInfo.add(JSON.stringify({initialAlias: initialAlias, convertedAlias: convertedAlias}));
+      alias[initialAlias] = convertedAlias;
     }
   });
   for (const initialAlias in duplicate) {
     duplicate[initialAlias] = Array.from(duplicate[initialAlias]);
   }
-  geneInfo = _.map(Array.from(geneInfo), ele => { return JSON.parse(ele); });
-  return resultTemplate( unrecognized, duplicate, geneInfo );
+  return resultTemplate( unrecognized, duplicate, alias );
 };
 
 

--- a/src/server/external-services/pathway-commons.js
+++ b/src/server/external-services/pathway-commons.js
@@ -22,15 +22,16 @@ const _sanitize = (s) => {
 
 const _processPhrase = (phrase) => {
   return validatorGconvert(phrase.split(' '),{}).then(result => {
-    const genes = result.geneInfo.map(gene=>'xrefid:' + _sanitize(gene.initialAlias.toUpperCase()));
-    const otherIds = result.unrecognized.map(id=>{
+    let { unrecognized, alias  } = result;
+    const entities = _.keys( alias ).map( initialAlias =>'xrefid:' + _sanitize( initialAlias.toUpperCase()) );
+    const otherIds = unrecognized.map(id=>{
       id=id.toUpperCase();
       const recognized = /^SMP\d{5}$/.test(id) // check for a smpdb or chebi id
         ||/^CHEBI:\d+$/.test(id) && (id.length <= ("CHEBI:".length + 6));
       const sanitized = _sanitize(id);
       return recognized ? ( 'xrefid:' + sanitized ) : ( 'name:' + '*' + sanitized + '*' );
     });
-    return genes.concat(otherIds);
+    return entities.concat(otherIds);
   });
 };
 

--- a/src/server/routes/enrichment/index.js
+++ b/src/server/routes/enrichment/index.js
@@ -90,7 +90,7 @@ enrichmentRouter.post('/validation', (req, res) => {
   tmpOptions.target = req.body.targetDb;
   validatorGconvert(query, tmpOptions).then(gconvertResult => {
     res.json(gconvertResult);
-  }).catch( error => res.status( 400 ).send( error ) );
+  }).catch( error => res.status( 400 ).send( { "error": error.message } ));
 });
 
 
@@ -543,7 +543,7 @@ enrichmentRouter.post('/visualization', (req, res) => {
  *       required:
  *       - unrecognized
  *       - duplicate
- *       - geneInfo
+ *       - alias
  *       properties:
  *         unrecognized:
  *           type: array
@@ -557,17 +557,12 @@ enrichmentRouter.post('/visualization', (req, res) => {
  *             items:
  *               type: string
  *               example: '11998'
- *         geneInfo:
- *           type: array
- *           items:
- *             type: object
- *             properties:
- *               initialAlias:
- *                 type: string
- *                 example: TP53
- *               convertedAlias:
- *                 type: string
- *                 example: HGNC:11998
+ *         alias:
+ *           type: object
+ *           properties:
+ *             initial alias (TP53):
+ *               type: string
+ *               example: converted alias (HGNC:11998)
  *     analysisSuccess:
  *       type: object
  *       required:

--- a/test/server/enrichment/validation/validation-test.js
+++ b/test/server/enrichment/validation/validation-test.js
@@ -2,110 +2,70 @@ const chai = require('chai');
 const expect = chai.expect;
 const { validatorGconvert } = require('../../../../src/server/external-services/gprofiler');
 
+const validResult_default = {
+	"unrecognized": [
+		"ATP"
+	],
+	"duplicate": {
+		"HGNC:11998": [
+			"TP53"
+		]
+	},
+	"alias": {
+    "TP53": "HGNC:11998",
+    "ATM": "HGNC:795"
+  }
+};
+
+const validResult_ENSG = {
+	"unrecognized": [
+		"ATP"
+	],
+	"duplicate": {
+		"ENSG00000141510": [
+			"TP53"
+		]
+	},
+	"alias": {
+    "TP53": "ENSG00000141510",
+    "ATM": "ENSG00000149311"
+  }
+};
+
 describe('Test validatorGconvert - Enrichment Validation Service', function() {
-  this.timeout(500000);
-  it('parameters: valid genes', function() {
-    return (validatorGconvert(['TP53', 'ATP', 'ATM', 'TP53'],{})).then(
-      //resolved
-      res => {
-      const result = {
-        "unrecognized": [
-          "ATP"
-        ],
-        "duplicate": {
-          "HGNC:11998": [
-            "TP53"
-          ]
-        },
-        "geneInfo": [
-          {
-            "initialAlias": "TP53",
-            "convertedAlias": "HGNC:11998"
-          },
-          {
-            "initialAlias": "ATM",
-            "convertedAlias": "HGNC:795"
-          }
-        ]
-      };
-      expect(res).to.deep.equal(result);
-      },
-      //rejected
-      (rej) => {
-      console.log("rejected");
-      }
-    );
+
+  it('should return correct results when no additional options are supplied', async () => {
+    const result = await validatorGconvert(["TP53", "ATP", "ATM", "TP53"], {});
+    expect( result ).to.deep.equal( validResult_default );
   });
 
-  it('parameters: valid genes, valid targetDb, valid organism', function() {
-    return (validatorGconvert(['TP53', 'ATP', 'ATM', 'TP53'], {target: "ensg", organism: "hsapiens" })).then(
-      //resolved
-      (res) => {
-      const result = {
-        "unrecognized": [
-          "ATP"
-        ],
-        "duplicate": {
-          "ENSG00000141510": [
-            "TP53"
-          ]
-        },
-        "geneInfo": [
-          {
-            "initialAlias": "TP53",
-            "convertedAlias": "ENSG00000141510"
-          },
-          {
-            "initialAlias": "ATM",
-            "convertedAlias": "ENSG00000149311"
-          }
-        ]
-      };
-      expect(res).to.deep.equal(result);
-      },
-      //rejected
-      (rej) => {
-      console.log("rejected");
-      }
-    );
+  it('should return correct results when options are specified', async () => {
+    const result = await validatorGconvert(["TP53", "ATP", "ATM", "TP53"], {target: "ENSG", organism: "hsapiens" });
+    expect( result ).to.deep.equal( validResult_ENSG );
   });
 
-  it('parameters: valid genes, valid targetDb, invalid organism', function() {
-    return (validatorGconvert(['TP53', 'ATP', 'ATM', 'TP53'], {target: "ENSG", organism: "dog" })).then(
-        //resolved
-        (res) => {
-        console.log("resolved");
-        },
-        //rejected
-        (rej) => {
-        expect(true);
-        }
-    );
+  it('should reject when invalid organism is specified', async () => {
+    try {
+      await validatorGconvert(["TP53", "ATP", "ATM", "TP53"], { organism: "human" });
+    } catch( err ) {
+      expect( err.message ).to.equal( "Invalid organism" );
+    }
   });
 
-  it('parameters: valid genes, invalid targetDb, valid organism', function() {
-    return (validatorGconvert(['TP53', 'ATP', 'ATM', 'TP53'], {target: "layman", organism: "hsapiens" })).then(
-        //resolved
-        (res) =>  {
-        console.log("resolved");
-        },
-        //rejected
-        (rej) => {
-        expect(true);
-        }
-    );
+  it('should reject when invalid target is specified', async () => {
+    try {
+      await validatorGconvert(["TP53", "ATP", "ATM", "TP53"], { target: "nonexistantdatabase" });
+    } catch( err ) {
+      expect( err.message ).to.equal( "Invalid target" );
+    }
   });
 
-  it('parameters: valid genes, invalid targetDb, invalid organism', function() {
-    return (validatorGconvert(['TP53', 'ATP', 'ATM', 'TP53'], {target: "layman", organism: "dog" })).then(
-       //resolved
-       (res) =>  {
-       console.log("resolved");
-       },
-       //rejected
-       (rej) => {
-        expect(true);
-       }
-    );
+  it('should reject when invalid options are specified', async () => {
+    try {
+      await validatorGconvert(["TP53", "ATP", "ATM", "TP53"], { target: "nonexistantdatabase", organism: "human" });
+    } catch( err ) {
+      expect( err ).to.be.instanceOf( Error );
+    }
   });
+
 });


### PR DESCRIPTION
Relates to #1103: validation

   - updated validation tests that were always returning 'pass'
   - validation service returns a plain `alias` object 
   - accommodating changes for dependencies in client  