### PR TITLE
Moving 'info' data fetch to server

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,8 @@ let defaults = {
   PC_URL: 'http://www.pathwaycommons.org/',
   GPROFILER_URL: "http://biit.cs.ut.ee/gprofiler_archive3/r1741_e90_eg37/web/",
   NCBI_EUTILS_BASE_URL: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils',
+  HGNC_BASE_URL: 'https://rest.genenames.org',
+  UNIPROT_API_BASE_URL: 'https://www.ebi.ac.uk/proteins/api',
   PC_CACHE_MAX_SIZE: 1000,
   PUB_CACHE_MAX_SIZE: 1000000,
   MAX_SIF_NODES: 25,

--- a/src/models/entity/summary.js
+++ b/src/models/entity/summary.js
@@ -1,0 +1,14 @@
+// Entity summary
+class EntitySummary {
+  constructor( dataSource, displayName, localID, description, aliasName, aliasId, xref ){
+    this.dataSource = dataSource || '';
+    this.displayName = displayName || '';
+    this.localID = localID || '';
+    this.description = description || '';
+    this.aliasName = aliasName || [];
+    this.aliasId = aliasId || [];
+    this.xref = xref || {};
+  }
+}
+
+module.exports = { EntitySummary };

--- a/src/models/entity/summary.js
+++ b/src/models/entity/summary.js
@@ -1,4 +1,7 @@
 // Entity summary
+const _ = require('lodash');
+
+//To be moved and integrated with all the other 'datasource'
 const DATASOURCES = {
   NCBIGENE: 'http://identifiers.org/ncbigene/',
   HGNC: 'http://identifiers.org/hgnc/',
@@ -6,15 +9,19 @@ const DATASOURCES = {
   GENECARDS: 'http://identifiers.org/genecards/'
 };
 
+const DEFAULTS = {
+  dataSource: '',
+  displayName: '',
+  localID: '',
+  description: '',
+  aliases: [],
+  aliasIds: [],
+  xref: {}
+};
+
 class EntitySummary {
-  constructor( dataSource, displayName, localID, description, aliases, aliasIds, xref ){
-    this.dataSource = dataSource || '';
-    this.displayName = displayName || '';
-    this.localID = localID || '';
-    this.description = description || '';
-    this.aliases = aliases || [];
-    this.aliasIds = aliasIds || [];
-    this.xref = xref || {};
+  constructor( options ){
+    _.assign(this, DEFAULTS, options );
   }
 }
 

--- a/src/models/entity/summary.js
+++ b/src/models/entity/summary.js
@@ -1,4 +1,11 @@
 // Entity summary
+const DATASOURCES = {
+  NCBIGENE: 'http://identifiers.org/ncbigene/',
+  HGNC: 'http://identifiers.org/hgnc/',
+  UNIPROT: 'http://identifiers.org/uniprot/',
+  GENECARDS: 'http://identifiers.org/genecards/'
+};
+
 class EntitySummary {
   constructor( dataSource, displayName, localID, description, aliasName, aliasId, xref ){
     this.dataSource = dataSource || '';
@@ -11,4 +18,4 @@ class EntitySummary {
   }
 }
 
-module.exports = { EntitySummary };
+module.exports = { EntitySummary, DATASOURCES };

--- a/src/models/entity/summary.js
+++ b/src/models/entity/summary.js
@@ -7,13 +7,13 @@ const DATASOURCES = {
 };
 
 class EntitySummary {
-  constructor( dataSource, displayName, localID, description, aliasName, aliasId, xref ){
+  constructor( dataSource, displayName, localID, description, aliases, aliasIds, xref ){
     this.dataSource = dataSource || '';
     this.displayName = displayName || '';
     this.localID = localID || '';
     this.description = description || '';
-    this.aliasName = aliasName || [];
-    this.aliasId = aliasId || [];
+    this.aliases = aliases || [];
+    this.aliasIds = aliasIds || [];
     this.xref = xref || {};
   }
 }

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -17,8 +17,7 @@ const fetchBySymbols = async symbols => {
   const docs = symbols.map( async symbol => {
     // Process each symbol individually
     const result = await fetchBySymbol( symbol );
-    if( result.response.numFound !== 1 ) return;
-    return result.response.docs[0];
+    return result;
   });
   return await Promise.all( docs );
 };
@@ -29,7 +28,9 @@ const getEntitySummary = async symbols => {
   if ( _.isEmpty( symbols ) ) return summary;
 
   const results = await fetchBySymbols( symbols );
-  results.forEach( doc => {
+  const nonEmptyResults = _.filter( results, o => _.get( o, 'response.numFound') );
+  const docList = _.map( nonEmptyResults, o => _.get( o, 'response.docs[0]') );
+  docList.forEach( doc => {
 
     const symbol = _.get( doc, 'symbol', '');
     const eSummary = new EntitySummary(

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -28,8 +28,8 @@ const getEntitySummary = async symbols => {
   if ( _.isEmpty( symbols ) ) return summary;
 
   const results = await fetchBySymbols( symbols );
-  const nonEmptyResults = _.filter( results, o => _.get( o, 'response.numFound') );
-  const docList = _.map( nonEmptyResults, o => _.get( o, 'response.docs[0]') );
+  const nonEmptyResults = results.filter( o => _.get( o, 'response.numFound') );
+  const docList = nonEmptyResults.map( o => _.get( o, 'response.docs[0]') );
   docList.forEach( doc => {
 
     const symbol = _.get( doc, 'symbol', '');

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -1,0 +1,59 @@
+const fetch = require('node-fetch');
+const _ = require('lodash');
+const { HGNC_BASE_URL } = require('../../config');
+const { EntitySummary } = require('../../models/entity/summary');
+
+const fetchBySymbol = symbol => {
+  return fetch( `${HGNC_BASE_URL}/fetch/symbol/${symbol}`,
+    { headers: {
+      'Accept': 'application/json'
+      }
+    })
+    .then(res => res.json());
+};
+
+const fetchBySymbols = async symbols => {
+  const docs = symbols.map( async symbol => {
+    // Process each symbol individually
+    const result = await fetchBySymbol( symbol );
+    if( result.response.numFound !== 1 ) return;
+    return result.response.docs[0];
+  });
+  return await Promise.all( docs );
+};
+
+const getEntitySummary = async symbols => {
+
+  const summary = {};
+  if ( _.isEmpty( symbols ) ) return summary;
+
+  const results = await fetchBySymbols( symbols );
+  results.forEach( doc => {
+
+    const symbol = _.get( doc, 'symbol', '');
+    const eSummary = new EntitySummary(
+      'http://identifiers.org/hgnc.symbol/',
+      _.get( doc, 'name', ''),
+      symbol,
+      '',
+      _.get( doc, 'alias_name', []),
+      _.get( doc, 'alias_symbol', []),
+      {
+        'http://identifiers.org/genecards/' : symbol
+      }
+    );
+    // Add database links
+    if ( _.has( doc, 'entrez_id') ){
+      eSummary.xref['http://identifiers.org/ncbigene/']  = _.get( doc, 'entrez_id');
+    }
+    if ( _.has( doc, 'uniprot_ids') ){
+      eSummary.xref['http://identifiers.org/uniprot/'] = _.get( doc, 'uniprot_ids[0]', '');
+    }
+
+    return summary[ symbol ] = eSummary;
+  });
+
+  return summary;
+};
+
+module.exports = { getEntitySummary };

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch');
 const _ = require('lodash');
 const { HGNC_BASE_URL } = require('../../config');
 const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
+const logger = require('../logger');
 
 //Could cache somewhere here.
 const fetchBySymbol = symbol => {
@@ -10,7 +11,11 @@ const fetchBySymbol = symbol => {
       'Accept': 'application/json'
       }
     })
-    .then(res => res.json());
+    .then(res => res.json())
+    .catch( error => {
+      logger.error(`${error.name} in hgnc fetchBySymbol: ${error.message}`);
+      throw error;
+    });
 };
 
 const fetchBySymbols = async symbols => {

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 const _ = require('lodash');
 const { HGNC_BASE_URL } = require('../../config');
-const { EntitySummary } = require('../../models/entity/summary');
+const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
 
 const fetchBySymbol = symbol => {
   return fetch( `${HGNC_BASE_URL}/fetch/symbol/${symbol}`,
@@ -32,22 +32,22 @@ const getEntitySummary = async symbols => {
 
     const symbol = _.get( doc, 'symbol', '');
     const eSummary = new EntitySummary(
-      'http://identifiers.org/hgnc.symbol/',
+      DATASOURCES.HGNC,
       _.get( doc, 'name', ''),
       symbol,
       '',
       _.get( doc, 'alias_name', []),
       _.get( doc, 'alias_symbol', []),
       {
-        'http://identifiers.org/genecards/' : symbol
+        [DATASOURCES.GENECARDS] : symbol
       }
     );
     // Add database links
     if ( _.has( doc, 'entrez_id') ){
-      eSummary.xref['http://identifiers.org/ncbigene/']  = _.get( doc, 'entrez_id');
+      eSummary.xref[DATASOURCES.NCBIGENE]  = _.get( doc, 'entrez_id');
     }
     if ( _.has( doc, 'uniprot_ids') ){
-      eSummary.xref['http://identifiers.org/uniprot/'] = _.get( doc, 'uniprot_ids[0]', '');
+      eSummary.xref[DATASOURCES.UNIPROT] = _.get( doc, 'uniprot_ids[0]', '');
     }
 
     return summary[ symbol ] = eSummary;

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const { HGNC_BASE_URL } = require('../../config');
 const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
 
+//Could cache somewhere here.
 const fetchBySymbol = symbol => {
   return fetch( `${HGNC_BASE_URL}/fetch/symbol/${symbol}`,
     { headers: {

--- a/src/server/external-services/ncbi.js
+++ b/src/server/external-services/ncbi.js
@@ -91,7 +91,7 @@ const getEntitySummary = async ( uids ) => {
       _.get( doc, 'uid', ''),
       _.get( doc, 'summary', ''),
       _.get( doc, 'otherdesignations', '').split('|'),
-      _.get( doc, 'otheraliases', '').split(',')
+      _.get( doc, 'otheraliases', '').split(',').map( a => a.trim() )
     );
 
     // Add database links

--- a/src/server/external-services/ncbi.js
+++ b/src/server/external-services/ncbi.js
@@ -4,6 +4,7 @@ const { URLSearchParams } = require('url');
 const LRUCache = require('lru-cache');
 const _ = require('lodash');
 const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
+const logger = require('../logger');
 
 const pubCache = LRUCache({ max: PUB_CACHE_MAX_SIZE, length: () => 1 });
 
@@ -71,7 +72,11 @@ const fetchByGeneIds = ( geneIds ) => {
         'Accept': 'application/json'
       }
     })
-    .then(res => res.json());
+    .then(res => res.json())
+    .catch( error => {
+      logger.error(`${error.name} in ncbi fetchByGeneIds: ${error.message}`);
+      throw error;
+    });
 };
 
 const getEntitySummary = async ( uids ) => {

--- a/src/server/external-services/ncbi.js
+++ b/src/server/external-services/ncbi.js
@@ -62,6 +62,7 @@ const getPublications = (pubmedIds) => {
   );
 };
 
+//Could cache somewhere here.
 const fetchByGeneIds = ( geneIds ) => {
   return fetch(`${NCBI_EUTILS_BASE_URL}/esummary.fcgi?retmode=json&db=gene&id=${geneIds.join(',')}`,
     {

--- a/src/server/external-services/ncbi.js
+++ b/src/server/external-services/ncbi.js
@@ -3,7 +3,7 @@ const { NCBI_EUTILS_BASE_URL, PUB_CACHE_MAX_SIZE } = require('../../config');
 const { URLSearchParams } = require('url');
 const LRUCache = require('lru-cache');
 const _ = require('lodash');
-const { EntitySummary } = require('../../models/entity/summary');
+const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
 
 const pubCache = LRUCache({ max: PUB_CACHE_MAX_SIZE, length: () => 1 });
 
@@ -86,7 +86,7 @@ const getEntitySummary = async ( uids ) => {
     const doc = result[ uid ];
 
     const eSummary = new EntitySummary(
-      'http://identifiers.org/ncbigene/',
+      DATASOURCES.NCBIGENE,
       _.get( doc, 'description', ''),
       _.get( doc, 'uid', ''),
       _.get( doc, 'summary', ''),
@@ -96,8 +96,8 @@ const getEntitySummary = async ( uids ) => {
 
     // Add database links
     if ( _.has( doc, 'name' ) ){
-      eSummary.xref['http://identifiers.org/hgnc.symbol/'] = _.get( doc, 'name' ,'');
-      eSummary.xref['http://identifiers.org/genecards/'] = _.get( doc, 'name', '');
+      eSummary.xref[DATASOURCES.HGNC] = _.get( doc, 'name' ,'');
+      eSummary.xref[DATASOURCES.GENECARDS] = _.get( doc, 'name', '');
     }
     return summary[ uid ] = eSummary;
   });

--- a/src/server/external-services/ncbi.js
+++ b/src/server/external-services/ncbi.js
@@ -90,21 +90,24 @@ const getEntitySummary = async ( uids ) => {
   result.uids.forEach( uid => {
     if( _.has( result, uid['error'] ) ) return;
     const doc = result[ uid ];
+    const xref = {};
 
-    const eSummary = new EntitySummary(
-      DATASOURCES.NCBIGENE,
-      _.get( doc, 'description', ''),
-      _.get( doc, 'uid', ''),
-      _.get( doc, 'summary', ''),
-      _.get( doc, 'otherdesignations', '').split('|'),
-      _.get( doc, 'otheraliases', '').split(',').map( a => a.trim() )
-    );
-
-    // Add database links
+    // Fetch external database links first
     if ( _.has( doc, 'name' ) ){
-      eSummary.xref[DATASOURCES.HGNC] = _.get( doc, 'name' ,'');
-      eSummary.xref[DATASOURCES.GENECARDS] = _.get( doc, 'name', '');
+      xref[DATASOURCES.HGNC] = _.get( doc, 'name' ,'');
+      xref[DATASOURCES.GENECARDS] = _.get( doc, 'name', '');
     }
+
+    const eSummary = new EntitySummary({
+      dataSource: DATASOURCES.NCBIGENE,
+      displayName: _.get( doc, 'description', ''),
+      localID: _.get( doc, 'uid', ''),
+      description: _.get( doc, 'summary', ''),
+      aliases: _.get( doc, 'otherdesignations', '').split('|'),
+      aliasIds: _.get( doc, 'otheraliases', '').split(',').map( a => a.trim() ),
+      xref: xref
+    });
+
     return summary[ uid ] = eSummary;
   });
 

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -3,7 +3,7 @@ const { UNIPROT_API_BASE_URL } = require('../../config');
 const _ = require('lodash');
 const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
 
-
+//Could cache somewhere here.
 const fetchByAccessions = ( accessions ) => {
   return fetch( `${UNIPROT_API_BASE_URL}/proteins?offset=0&accession=${accessions.join(',')}`,
     { headers: {

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch');
 const { UNIPROT_API_BASE_URL } = require('../../config');
 const _ = require('lodash');
 const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
+const logger = require('../logger');
 
 //Could cache somewhere here.
 const fetchByAccessions = ( accessions ) => {
@@ -10,7 +11,11 @@ const fetchByAccessions = ( accessions ) => {
       'Accept': 'application/json'
       }
     })
-    .then(res => res.json());
+    .then(res => res.json())
+    .catch( error => {
+      logger.error(`${error.name} in uniprot fetchByAccessions: ${error.message}`);
+      throw error;
+    });
 };
 
 const getEntitySummary = async ( accessions ) => {

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 const { UNIPROT_API_BASE_URL } = require('../../config');
 const _ = require('lodash');
-const { EntitySummary } = require('../../models/entity/summary');
+const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
 
 
 const fetchByAccessions = ( accessions ) => {
@@ -25,7 +25,7 @@ const getEntitySummary = async ( accessions ) => {
 
     const accession = _.get( doc, 'accession', '');
     const eSummary = new EntitySummary(
-      'http://identifiers.org/uniprot/',
+      DATASOURCES.UNIPROT,
       _.get( doc, 'protein.recommendedName.fullName.value', ''),
       accession,
       _.get( doc, 'comments[0].text[0].value', ''),
@@ -36,13 +36,13 @@ const getEntitySummary = async ( accessions ) => {
     // Add database links
     doc.dbReferences.forEach( xrf => {
       if ( xrf.type === 'GeneID' ) {
-        eSummary.xref['http://identifiers.org/ncbigene/']
+        eSummary.xref[DATASOURCES.NCBIGENE]
           = _.get( xrf, 'id', '');
       }
       if ( xrf.type === 'HGNC' ) {
-        eSummary.xref['http://identifiers.org/hgnc.symbol/']
+        eSummary.xref[DATASOURCES.HGNC]
           =  _.get( xrf, "properties['gene designation']");
-          eSummary.xref['http://identifiers.org/genecards/']
+          eSummary.xref[DATASOURCES.GENECARDS]
           =  _.get( xrf, "properties['gene designation']");
       }
     });

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -1,0 +1,56 @@
+const fetch = require('node-fetch');
+const { UNIPROT_API_BASE_URL } = require('../../config');
+const _ = require('lodash');
+const { EntitySummary } = require('../../models/entity/summary');
+
+
+const fetchByAccessions = ( accessions ) => {
+  return fetch( `${UNIPROT_API_BASE_URL}/proteins?offset=0&accession=${accessions.join(',')}`,
+    { headers: {
+      'Accept': 'application/json'
+      }
+    })
+    .then(res => res.json());
+};
+
+const getEntitySummary = async ( accessions ) => {
+
+  const summary = {};
+  if ( _.isEmpty( accessions ) ) return summary;
+
+  const results = await fetchByAccessions( accessions );
+  if ( _.has( results, 'errorMessage') ) return summary;
+
+  results.forEach( doc => {
+
+    const accession = _.get( doc, 'accession', '');
+    const eSummary = new EntitySummary(
+      'http://identifiers.org/uniprot/',
+      _.get( doc, 'protein.recommendedName.fullName.value', ''),
+      accession,
+      _.get( doc, 'comments[0].text[0].value', ''),
+      _.get( doc, 'protein.alternativeName', []).map( elt =>  _.get( elt, 'fullName.value') ),
+      _.get( doc, 'protein.recommendedName.shortName', []).map( elt =>  _.get( elt, 'value') )
+    );
+
+    // Add database links
+    doc.dbReferences.forEach( xrf => {
+      if ( xrf.type === 'GeneID' ) {
+        eSummary.xref['http://identifiers.org/ncbigene/']
+          = _.get( xrf, 'id', '');
+      }
+      if ( xrf.type === 'HGNC' ) {
+        eSummary.xref['http://identifiers.org/hgnc.symbol/']
+          =  _.get( xrf, "properties['gene designation']");
+          eSummary.xref['http://identifiers.org/genecards/']
+          =  _.get( xrf, "properties['gene designation']");
+      }
+    });
+
+    return summary[ accession ] = eSummary;
+  });
+
+  return summary;
+};
+
+module.exports = { getEntitySummary };

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const pc = require('./pathway-commons-router');
+const summary = require('./summary');
 
 
+router.use('/api/summary', summary);
 router.use('/api/pc', pc);
 router.use('/api/pathways', require('./pathways'));
 router.use('/api/interactions', require('./interactions'));

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -38,7 +38,7 @@ const entitySearch = async tokens => {
   // look for special tokens
   if ( tokens.length === 1 ) {
     const token = tokens[0];
-    const [ dbId, entityId ] = token.split(':');
+    const [ dbId, entityId ] = token.split(':'); // eslint-disable-line no-unused-vars
     if( /hgnc:\w+$/i.test( token ) ){
       return getHgncSummary( [ entityId ], DATASOURCES.HGNC );
     } else if ( /ncbi:[0-9]+$/i.test( token ) ) {

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -68,7 +68,10 @@ const entitySearch = async tokens => {
 
   // Want key to be original input token, unfortunately, validator transforms to upper case
   const output =  {};
-  _.entries( alias ).forEach( pair => output[ pair[0] ] = summary[ pair[1] ] );
+  _.entries( alias ).forEach( pair => {
+    const tokenIndex =  _.findIndex( uniqueTokens, t => t.toUpperCase() ===  pair[0] );
+    output[ uniqueTokens[tokenIndex] ] = summary[ pair[1] ];
+});
 
   return output;
 };

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -64,7 +64,7 @@ const entitySearch = async tokens => {
     if ( eSummary ) eSummary.xref[DATASOURCES.UNIPROT] = _.get( aliasUniProt, ncbiId );
   });
 
-  // Want key to be original input token
+  // Want key to be original input token, unfortunately, validator transforms to upper case
   const output =  {};
   _.entries( alias ).forEach( pair => output[pair[0]] = summary[pair[1]] );
 

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -40,11 +40,27 @@ const entityFetch = async ( localIds, dataSource ) => {
  */
 const entitySearch = async tokens => {
 
+  let summary = {};
+
+  // look for special tokens
+  if ( tokens.length === 1 ) {
+    const token = tokens[0];
+    const [ dbId, entityId ] = token.split(':');
+    if( /hgnc:\w+$/i.test( token ) ){
+      summary = await getHgncSummary( [ entityId ], dataSources.HGNC );
+    } else if ( /ncbi:[0-9]+$/i.test( token ) ) {
+      summary = await getNcbiGeneSummary( [ entityId ], dataSources.NCBIGENE );
+    } else if( /uniprot:\w+$/i.test( token ) ){
+      summary = await getUniProtSummary( [ entityId ], dataSources.UNIPROT );
+    }
+    return summary;
+  }
+
   const { alias } = await validatorGconvert( tokens, { target: 'NCBIGene' } );
   const  ncbiIds = _.values( alias );
 
   // get the entity references
-  const summary = await entityFetch( ncbiIds );
+  summary = await entityFetch( ncbiIds );
 
   // NCBI Gene won't give UniProt Accession, so gotta go get em
   const { alias: aliasUniProt } = await validatorGconvert( ncbiIds, { target: 'UniProt' } );

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -50,23 +50,25 @@ const entitySearch = async tokens => {
 
   const uniqueTokens = _.uniq( tokens );
   const { alias } = await validatorGconvert( uniqueTokens, { target: 'NCBIGene' } );
-  const  ncbiIds = _.values( alias );
+  // Duplication of work (src/server/external-services/pathway-commons.js).
+  // Could consider a single piece of logic that tokenizes and sends to validator.
 
-  // get the entity references
-  const summary = await entityFetch( ncbiIds, DATASOURCES.NCBIGENE );
+  // get the entity summaries for successfully mapped tokens
+  const mappedIds = _.values( alias );
+  const summary = await entityFetch( mappedIds, DATASOURCES.NCBIGENE );
 
   // NCBI Gene won't give UniProt Accession, so gotta go get em
-  const { alias: aliasUniProt } = await validatorGconvert( ncbiIds, { target: 'UniProt' } );
+  const { alias: aliasUniProt } = await validatorGconvert( mappedIds, { target: 'UniProt' } );
 
   // Update the entity summaries
   _.keys( aliasUniProt ).forEach( ncbiId => {
     const eSummary = _.get( summary, ncbiId );
-    if ( eSummary ) eSummary.xref[DATASOURCES.UNIPROT] = _.get( aliasUniProt, ncbiId );
+    if ( eSummary ) eSummary.xref[ DATASOURCES.UNIPROT ] = _.get( aliasUniProt, ncbiId );
   });
 
   // Want key to be original input token, unfortunately, validator transforms to upper case
   const output =  {};
-  _.entries( alias ).forEach( pair => output[pair[0]] = summary[pair[1]] );
+  _.entries( alias ).forEach( pair => output[ pair[0] ] = summary[ pair[1] ] );
 
   return output;
 };

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -1,0 +1,31 @@
+const _ = require('lodash');
+const { validatorGconvert } = require('../../../external-services/gprofiler/gconvert');
+const { getEntitySummary: getNcbiGeneSummary } = require('../../../external-services/ncbi');
+
+/**
+ * entitySearch
+ *
+ * @param { array } tokens string(s) that should be queried
+ * @return { object } and EntitySummary keyed by the local ID
+ */
+const entitySearch = async tokens => {
+
+  const { alias } = await validatorGconvert( tokens, { target: 'NCBIGene' } );
+  const  ncbiIds = _.values( alias );
+
+  // get the entity references
+  const summary = await getNcbiGeneSummary( ncbiIds );
+
+  // // // NCBI Gene won't give UniProt Accession, so gotta go get em
+  const { alias: aliasUniProt } = await validatorGconvert( ncbiIds, { target: 'UniProt' } );
+
+  // Update the entity summaries
+  _.keys( aliasUniProt ).forEach( ncbiId => {
+    const eSummary = _.get( summary, ncbiId );
+    if ( eSummary ) eSummary.xref['http://identifiers.org/uniprot/'] = _.get( aliasUniProt, ncbiId );
+  });
+
+  return summary;
+};
+
+module.exports = { entitySearch };

--- a/src/server/routes/summary/index.js
+++ b/src/server/routes/summary/index.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const { entitySearch } = require('./entity');
+
+router.get('/entity/search', function (req, res) {
+  let tokens = req.query.q.trim().split(' ');
+  entitySearch( tokens ).then( r => res.json( r ) );
+});
+
+module.exports = router;

--- a/src/server/routes/summary/index.js
+++ b/src/server/routes/summary/index.js
@@ -6,7 +6,7 @@ router.get('/entity/search', function (req, res) {
   let tokens = req.query.q.trim().split(' ');
   entitySearch( tokens )
     .then( r => res.json( r ) )
-    .catch( e => res.status( 500 ).send( { "error": "Server error" } ));  // eslint-disable-line no-unused-vars
+    .catch( e => res.status( 500 ).end( "Server error" ) );  // eslint-disable-line no-unused-vars
 });
 
 module.exports = router;

--- a/src/server/routes/summary/index.js
+++ b/src/server/routes/summary/index.js
@@ -4,7 +4,9 @@ const { entitySearch } = require('./entity');
 
 router.get('/entity/search', function (req, res) {
   let tokens = req.query.q.trim().split(' ');
-  entitySearch( tokens ).then( r => res.json( r ) );
+  entitySearch( tokens )
+    .then( r => res.json( r ) )
+    .catch( e => res.status( 500 ).send( { "error": "Server error" } ));  // eslint-disable-line no-unused-vars
 });
 
 module.exports = router;

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -1,0 +1,73 @@
+const chai = require('chai');
+const expect = chai.expect;
+const { entitySearch } = require('../../../src/server/routes/summary/entity');
+
+const validResult = {
+	"4193": {
+		"dataSource": "http://identifiers.org/ncbigene/",
+		"displayName": "MDM2 proto-oncogene",
+		"localID": "4193",
+		"description": "This gene encodes a nuclear-localized E3 ubiquitin ligase. The encoded protein can promote tumor formation by targeting tumor suppressor proteins, such as p53, for proteasomal degradation. This gene is itself transcriptionally-regulated by p53. Overexpression or amplification of this locus is detected in a variety of different cancers. There is a pseudogene for this gene on chromosome 2. Alternative splicing results in a multitude of transcript variants, many of which may be expressed only in tumor cells. [provided by RefSeq, Jun 2013]",
+		"aliasName": [
+			"E3 ubiquitin-protein ligase Mdm2",
+			"MDM2 oncogene, E3 ubiquitin protein ligase",
+			"MDM2 proto-oncogene, E3 ubiquitin protein ligase",
+			"Mdm2, p53 E3 ubiquitin protein ligase homolog",
+			"Mdm2, transformed 3T3 cell double minute 2, p53 binding protein",
+			"double minute 2, human homolog of; p53-binding protein",
+			"oncoprotein Mdm2"
+		],
+		"aliasId": [
+			"ACTFS",
+			" HDMX",
+			" hdm2"
+		],
+		"xref": {
+			"http://identifiers.org/hgnc.symbol/": "MDM2",
+			"http://identifiers.org/genecards/": "MDM2",
+			"http://identifiers.org/uniprot/": "Q00987"
+		}
+	},
+	"7157": {
+		"dataSource": "http://identifiers.org/ncbigene/",
+		"displayName": "tumor protein p53",
+		"localID": "7157",
+		"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
+		"aliasName": [
+			"cellular tumor antigen p53",
+			"antigen NY-CO-13",
+			"mutant tumor protein 53",
+			"p53 tumor suppressor",
+			"phosphoprotein p53",
+			"transformation-related protein 53",
+			"tumor protein 53",
+			"tumor supressor p53"
+		],
+		"aliasId": [
+			"BCC7",
+			" LFS1",
+			" P53",
+			" TRP53"
+		],
+		"xref": {
+			"http://identifiers.org/hgnc.symbol/": "TP53",
+			"http://identifiers.org/genecards/": "TP53",
+			"http://identifiers.org/uniprot/": "P04637"
+		}
+	}
+};
+
+describe('Test of summary entitySearch function', function() {
+  this.timeout( 10000 );
+
+  it('should return correct summary for two valid HGNC symbols', async () => {
+    const result = await entitySearch(['TP53', 'MDM2']);
+    expect( result ).to.deep.equal( validResult );
+  });
+
+  it('should return empty summary for tokens not known to be IDs', async () => {
+    const result = await entitySearch(['foo', 'bar']);
+    expect( result ).to.be.an('object').that.is.empty;
+  });
+
+});

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -253,7 +253,7 @@ describe('Test of summary entitySearch function', function() {
     expect( result ).to.deep.equal( validResult_prefixed_HGNC );
 	});
 
-	it('should return correct summary for prefixed HGNC symbol', async () => {
+	it('should return correct summary for prefixed uniprot accession', async () => {
     const result = await entitySearch(['uniprot:P04637']);
     expect( result ).to.deep.equal( validResult_prefixed_UNIPROT );
   });

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -1,7 +1,11 @@
 const chai = require('chai');
 const expect = chai.expect;
-const { entitySearch } = require('../../../src/server/routes/summary/entity');
-
+const { entitySearch, entityFetch } = require('../../../src/server/routes/summary/entity');
+const dataSources = {
+  NCBIGENE: 'http://identifiers.org/ncbigene/',
+  HGNC: 'http://identifiers.org/hgnc/',
+  UNIPROT: 'http://identifiers.org/uniprot/'
+};
 const validResult = {
 	"4193": {
 		"dataSource": "http://identifiers.org/ncbigene/",
@@ -57,6 +61,140 @@ const validResult = {
 	}
 };
 
+const validResult_NCBIGENE = {
+	"4193": {
+		"dataSource": "http://identifiers.org/ncbigene/",
+		"displayName": "MDM2 proto-oncogene",
+		"localID": "4193",
+		"description": "This gene encodes a nuclear-localized E3 ubiquitin ligase. The encoded protein can promote tumor formation by targeting tumor suppressor proteins, such as p53, for proteasomal degradation. This gene is itself transcriptionally-regulated by p53. Overexpression or amplification of this locus is detected in a variety of different cancers. There is a pseudogene for this gene on chromosome 2. Alternative splicing results in a multitude of transcript variants, many of which may be expressed only in tumor cells. [provided by RefSeq, Jun 2013]",
+		"aliasName": [
+			"E3 ubiquitin-protein ligase Mdm2",
+			"MDM2 oncogene, E3 ubiquitin protein ligase",
+			"MDM2 proto-oncogene, E3 ubiquitin protein ligase",
+			"Mdm2, p53 E3 ubiquitin protein ligase homolog",
+			"Mdm2, transformed 3T3 cell double minute 2, p53 binding protein",
+			"double minute 2, human homolog of; p53-binding protein",
+			"oncoprotein Mdm2"
+		],
+		"aliasId": [
+			"ACTFS",
+			" HDMX",
+			" hdm2"
+		],
+		"xref": {
+			"http://identifiers.org/hgnc.symbol/": "MDM2",
+			"http://identifiers.org/genecards/": "MDM2"
+		}
+	},
+	"7157": {
+		"dataSource": "http://identifiers.org/ncbigene/",
+		"displayName": "tumor protein p53",
+		"localID": "7157",
+		"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
+		"aliasName": [
+			"cellular tumor antigen p53",
+			"antigen NY-CO-13",
+			"mutant tumor protein 53",
+			"p53 tumor suppressor",
+			"phosphoprotein p53",
+			"transformation-related protein 53",
+			"tumor protein 53",
+			"tumor supressor p53"
+		],
+		"aliasId": [
+			"BCC7",
+			" LFS1",
+			" P53",
+			" TRP53"
+		],
+		"xref": {
+			"http://identifiers.org/hgnc.symbol/": "TP53",
+			"http://identifiers.org/genecards/": "TP53"
+		}
+	}
+};
+
+
+const validResult_HGNC = {
+	"TP53":{
+		"dataSource":"http://identifiers.org/hgnc.symbol/",
+		"displayName":"tumor protein p53",
+		"localID":"TP53",
+		"description":"",
+		"aliasName":[
+			"Li-Fraumeni syndrome"
+		],
+		"aliasId":[
+			"p53",
+			"LFS1"
+		],
+		"xref":{
+			"http://identifiers.org/genecards/":"TP53",
+			"http://identifiers.org/ncbigene/":"7157",
+			"http://identifiers.org/uniprot/":"P04637"
+		}
+	},
+	"MDM2":{
+		"dataSource":"http://identifiers.org/hgnc.symbol/",
+		"displayName":"MDM2 proto-oncogene",
+		"localID":"MDM2",
+		"description":"",
+		"aliasName":[
+		],
+		"aliasId":[
+			"HDM2",
+			"MGC5370"
+		],
+		"xref":{
+			"http://identifiers.org/genecards/":"MDM2",
+			"http://identifiers.org/ncbigene/":"4193",
+			"http://identifiers.org/uniprot/":"Q00987"
+		}
+	}
+};
+
+const validResult_UNIPROT = {
+	"P04637":{
+		"dataSource":"http://identifiers.org/uniprot/",
+		"displayName":"Cellular tumor antigen p53",
+		"localID":"P04637",
+		"description":"Acts as a tumor suppressor in many tumor types; induces growth arrest or apoptosis depending on the physiological circumstances and cell type. Involved in cell cycle regulation as a trans-activator that acts to negatively regulate cell division by controlling a set of genes required for this process. One of the activated genes is an inhibitor of cyclin-dependent kinases. Apoptosis induction seems to be mediated either by stimulation of BAX and FAS antigen expression, or by repression of Bcl-2 expression. In cooperation with mitochondrial PPIF is involved in activating oxidative stress-induced necrosis; the function is largely independent of transcription. Induces the transcription of long intergenic non-coding RNA p21 (lincRNA-p21) and lincRNA-Mkln1. LincRNA-p21 participates in TP53-dependent transcriptional repression leading to apoptosis and seems to have an effect on cell-cycle regulation. Implicated in Notch signaling cross-over. Prevents CDK7 kinase activity when associated to CAK complex in response to DNA damage, thus stopping cell cycle progression. Isoform 2 enhances the transactivation activity of isoform 1 from some but not all TP53-inducible promoters. Isoform 4 suppresses transactivation activity and impairs growth suppression mediated by isoform 1. Isoform 7 inhibits isoform 1-mediated apoptosis. Regulates the circadian clock by repressing CLOCK-ARNTL/BMAL1-mediated transcriptional activation of PER2 (PubMed:24051492)",
+		"aliasName":[
+			"Antigen NY-CO-13",
+			"Phosphoprotein p53",
+			"Tumor suppressor p53"
+		],
+		"aliasId":[
+
+		],
+		"xref":{
+			"http://identifiers.org/ncbigene/":"7157",
+			"http://identifiers.org/hgnc.symbol/":"TP53",
+			"http://identifiers.org/genecards/":"TP53"
+		}
+	},
+	"Q00987":{
+		"dataSource":"http://identifiers.org/uniprot/",
+		"displayName":"E3 ubiquitin-protein ligase Mdm2",
+		"localID":"Q00987",
+		"description":"E3 ubiquitin-protein ligase that mediates ubiquitination of p53/TP53, leading to its degradation by the proteasome. Inhibits p53/TP53- and p73/TP73-mediated cell cycle arrest and apoptosis by binding its transcriptional activation domain. Also acts as a ubiquitin ligase E3 toward itself and ARRB1. Permits the nuclear export of p53/TP53. Promotes proteasome-dependent ubiquitin-independent degradation of retinoblastoma RB1 protein. Inhibits DAXX-mediated apoptosis by inducing its ubiquitination and degradation. Component of the TRIM28/KAP1-MDM2-p53/TP53 complex involved in stabilizing p53/TP53. Also component of the TRIM28/KAP1-ERBB4-MDM2 complex which links growth factor and DNA damage response pathways. Mediates ubiquitination and subsequent proteasome degradation of DYRK2 in nucleus. Ubiquitinates IGF1R and SNAI1 and promotes them to proteasomal degradation (PubMed:12821780, PubMed:15053880, PubMed:15195100, PubMed:15632057, PubMed:16337594, PubMed:17290220, PubMed:19098711, PubMed:19219073, PubMed:19837670, PubMed:19965871, PubMed:20173098, PubMed:20385133, PubMed:20858735, PubMed:22128911). Ubiquitinates DCX, leading to DCX degradation and reduction of the dendritic spine density of olfactory bulb granule cells (By similarity). Ubiquitinates DLG4, leading to proteasomal degradation of DLG4 which is required for AMPA receptor endocytosis",
+		"aliasName":[
+			"Double minute 2 protein",
+			"Oncoprotein Mdm2",
+			"RING-type E3 ubiquitin transferase Mdm2",
+			"p53-binding protein Mdm2"
+		],
+		"aliasId":[
+
+		],
+		"xref":{
+			"http://identifiers.org/ncbigene/":"4193",
+			"http://identifiers.org/hgnc.symbol/":"MDM2",
+			"http://identifiers.org/genecards/":"MDM2"
+		}
+	}
+};
+
 describe('Test of summary entitySearch function', function() {
   this.timeout( 10000 );
 
@@ -68,6 +206,26 @@ describe('Test of summary entitySearch function', function() {
   it('should return empty summary for tokens not known to be IDs', async () => {
     const result = await entitySearch(['foo', 'bar']);
     expect( result ).to.be.an('object').that.is.empty;
+  });
+
+});
+
+describe('Test of summary entityFetch function', function() {
+  this.timeout( 10000 );
+
+  it('should return correct summary for two valid NCBI Gene IDs', async () => {
+    const result = await entityFetch(['7157', '4193'], dataSources.NCBIGENE );
+    expect( result ).to.deep.equal( validResult_NCBIGENE );
+	});
+
+	it('should return correct summary for two valid HGNC symbols', async () => {
+    const result = await entityFetch(['TP53', 'MDM2'], dataSources.HGNC );
+    expect( result ).to.deep.equal( validResult_HGNC );
+	});
+
+	it('should return correct summary for two valid UniProt accessions', async () => {
+    const result = await entityFetch(['P04637', 'Q00987'], dataSources.UNIPROT );
+    expect( result ).to.deep.equal( validResult_UNIPROT );
   });
 
 });

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -248,6 +248,11 @@ describe('Test of summary entitySearch function', function() {
     expect( result ).to.be.an('object').that.is.empty;
 	});
 
+	it('should return correct summary for prefixed NCBI Gene ID', async () => {
+    const result = await entitySearch(['ncbi:7157']);
+    expect( result ).to.deep.equal( { "7157": validResult_NCBIGENE["7157"] } );
+	});
+
   it('should return correct summary for prefixed HGNC symbol', async () => {
     const result = await entitySearch(['hgnc:TP53']);
     expect( result ).to.deep.equal( validResult_prefixed_HGNC );

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -7,7 +7,7 @@ const dataSources = {
   UNIPROT: 'http://identifiers.org/uniprot/'
 };
 const validResult = {
-	"4193": {
+	"MDM2": {
 		"dataSource": "http://identifiers.org/ncbigene/",
 		"displayName": "MDM2 proto-oncogene",
 		"localID": "4193",
@@ -27,12 +27,12 @@ const validResult = {
 			" hdm2"
 		],
 		"xref": {
-			"http://identifiers.org/hgnc.symbol/": "MDM2",
+			"http://identifiers.org/hgnc/": "MDM2",
 			"http://identifiers.org/genecards/": "MDM2",
 			"http://identifiers.org/uniprot/": "Q00987"
 		}
 	},
-	"7157": {
+	"TP53": {
 		"dataSource": "http://identifiers.org/ncbigene/",
 		"displayName": "tumor protein p53",
 		"localID": "7157",
@@ -54,7 +54,7 @@ const validResult = {
 			" TRP53"
 		],
 		"xref": {
-			"http://identifiers.org/hgnc.symbol/": "TP53",
+			"http://identifiers.org/hgnc/": "TP53",
 			"http://identifiers.org/genecards/": "TP53",
 			"http://identifiers.org/uniprot/": "P04637"
 		}
@@ -63,7 +63,7 @@ const validResult = {
 
 const validResult_prefixed_HGNC = {
 	"TP53": {
-		"dataSource": "http://identifiers.org/hgnc.symbol/",
+		"dataSource": "http://identifiers.org/hgnc/",
 		"displayName": "tumor protein p53",
 		"localID": "TP53",
 		"description": "",
@@ -96,7 +96,7 @@ const validResult_prefixed_UNIPROT = {
 		"aliasId": [],
 		"xref": {
 			"http://identifiers.org/ncbigene/": "7157",
-			"http://identifiers.org/hgnc.symbol/": "TP53",
+			"http://identifiers.org/hgnc/": "TP53",
 			"http://identifiers.org/genecards/": "TP53"
 		}
 	}
@@ -123,7 +123,7 @@ const validResult_NCBIGENE = {
 			" hdm2"
 		],
 		"xref": {
-			"http://identifiers.org/hgnc.symbol/": "MDM2",
+			"http://identifiers.org/hgnc/": "MDM2",
 			"http://identifiers.org/genecards/": "MDM2"
 		}
 	},
@@ -149,7 +149,7 @@ const validResult_NCBIGENE = {
 			" TRP53"
 		],
 		"xref": {
-			"http://identifiers.org/hgnc.symbol/": "TP53",
+			"http://identifiers.org/hgnc/": "TP53",
 			"http://identifiers.org/genecards/": "TP53"
 		}
 	}
@@ -157,7 +157,7 @@ const validResult_NCBIGENE = {
 
 const validResult_HGNC = {
 	"TP53":{
-		"dataSource":"http://identifiers.org/hgnc.symbol/",
+		"dataSource":"http://identifiers.org/hgnc/",
 		"displayName":"tumor protein p53",
 		"localID":"TP53",
 		"description":"",
@@ -175,7 +175,7 @@ const validResult_HGNC = {
 		}
 	},
 	"MDM2":{
-		"dataSource":"http://identifiers.org/hgnc.symbol/",
+		"dataSource":"http://identifiers.org/hgnc/",
 		"displayName":"MDM2 proto-oncogene",
 		"localID":"MDM2",
 		"description":"",
@@ -209,7 +209,7 @@ const validResult_UNIPROT = {
 		],
 		"xref":{
 			"http://identifiers.org/ncbigene/":"7157",
-			"http://identifiers.org/hgnc.symbol/":"TP53",
+			"http://identifiers.org/hgnc/":"TP53",
 			"http://identifiers.org/genecards/":"TP53"
 		}
 	},
@@ -229,7 +229,7 @@ const validResult_UNIPROT = {
 		],
 		"xref":{
 			"http://identifiers.org/ncbigene/":"4193",
-			"http://identifiers.org/hgnc.symbol/":"MDM2",
+			"http://identifiers.org/hgnc/":"MDM2",
 			"http://identifiers.org/genecards/":"MDM2"
 		}
 	}

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -23,8 +23,8 @@ const validResult = {
 		],
 		"aliasId": [
 			"ACTFS",
-			" HDMX",
-			" hdm2"
+			"HDMX",
+			"hdm2"
 		],
 		"xref": {
 			"http://identifiers.org/hgnc/": "MDM2",
@@ -49,9 +49,9 @@ const validResult = {
 		],
 		"aliasId": [
 			"BCC7",
-			" LFS1",
-			" P53",
-			" TRP53"
+			"LFS1",
+			"P53",
+			"TRP53"
 		],
 		"xref": {
 			"http://identifiers.org/hgnc/": "TP53",
@@ -119,8 +119,8 @@ const validResult_NCBIGENE = {
 		],
 		"aliasId": [
 			"ACTFS",
-			" HDMX",
-			" hdm2"
+			"HDMX",
+			"hdm2"
 		],
 		"xref": {
 			"http://identifiers.org/hgnc/": "MDM2",
@@ -144,9 +144,9 @@ const validResult_NCBIGENE = {
 		],
 		"aliasId": [
 			"BCC7",
-			" LFS1",
-			" P53",
-			" TRP53"
+			"LFS1",
+			"P53",
+			"TRP53"
 		],
 		"xref": {
 			"http://identifiers.org/hgnc/": "TP53",

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -61,6 +61,47 @@ const validResult = {
 	}
 };
 
+const validResult_prefixed_HGNC = {
+	"TP53": {
+		"dataSource": "http://identifiers.org/hgnc.symbol/",
+		"displayName": "tumor protein p53",
+		"localID": "TP53",
+		"description": "",
+		"aliasName": [
+			"Li-Fraumeni syndrome"
+		],
+		"aliasId": [
+			"p53",
+			"LFS1"
+		],
+		"xref": {
+			"http://identifiers.org/genecards/": "TP53",
+			"http://identifiers.org/ncbigene/": "7157",
+			"http://identifiers.org/uniprot/": "P04637"
+		}
+	}
+};
+
+const validResult_prefixed_UNIPROT = {
+	"P04637": {
+		"dataSource": "http://identifiers.org/uniprot/",
+		"displayName": "Cellular tumor antigen p53",
+		"localID": "P04637",
+		"description": "Acts as a tumor suppressor in many tumor types; induces growth arrest or apoptosis depending on the physiological circumstances and cell type. Involved in cell cycle regulation as a trans-activator that acts to negatively regulate cell division by controlling a set of genes required for this process. One of the activated genes is an inhibitor of cyclin-dependent kinases. Apoptosis induction seems to be mediated either by stimulation of BAX and FAS antigen expression, or by repression of Bcl-2 expression. In cooperation with mitochondrial PPIF is involved in activating oxidative stress-induced necrosis; the function is largely independent of transcription. Induces the transcription of long intergenic non-coding RNA p21 (lincRNA-p21) and lincRNA-Mkln1. LincRNA-p21 participates in TP53-dependent transcriptional repression leading to apoptosis and seems to have an effect on cell-cycle regulation. Implicated in Notch signaling cross-over. Prevents CDK7 kinase activity when associated to CAK complex in response to DNA damage, thus stopping cell cycle progression. Isoform 2 enhances the transactivation activity of isoform 1 from some but not all TP53-inducible promoters. Isoform 4 suppresses transactivation activity and impairs growth suppression mediated by isoform 1. Isoform 7 inhibits isoform 1-mediated apoptosis. Regulates the circadian clock by repressing CLOCK-ARNTL/BMAL1-mediated transcriptional activation of PER2 (PubMed:24051492)",
+		"aliasName": [
+			"Antigen NY-CO-13",
+			"Phosphoprotein p53",
+			"Tumor suppressor p53"
+		],
+		"aliasId": [],
+		"xref": {
+			"http://identifiers.org/ncbigene/": "7157",
+			"http://identifiers.org/hgnc.symbol/": "TP53",
+			"http://identifiers.org/genecards/": "TP53"
+		}
+	}
+};
+
 const validResult_NCBIGENE = {
 	"4193": {
 		"dataSource": "http://identifiers.org/ncbigene/",
@@ -113,7 +154,6 @@ const validResult_NCBIGENE = {
 		}
 	}
 };
-
 
 const validResult_HGNC = {
 	"TP53":{
@@ -206,7 +246,18 @@ describe('Test of summary entitySearch function', function() {
   it('should return empty summary for tokens not known to be IDs', async () => {
     const result = await entitySearch(['foo', 'bar']);
     expect( result ).to.be.an('object').that.is.empty;
+	});
+
+  it('should return correct summary for prefixed HGNC symbol', async () => {
+    const result = await entitySearch(['hgnc:TP53']);
+    expect( result ).to.deep.equal( validResult_prefixed_HGNC );
+	});
+
+	it('should return correct summary for prefixed HGNC symbol', async () => {
+    const result = await entitySearch(['uniprot:P04637']);
+    expect( result ).to.deep.equal( validResult_prefixed_UNIPROT );
   });
+
 
 });
 

--- a/test/server/summary/summary-entity-search-test.js
+++ b/test/server/summary/summary-entity-search-test.js
@@ -12,7 +12,7 @@ const validResult = {
 		"displayName": "MDM2 proto-oncogene",
 		"localID": "4193",
 		"description": "This gene encodes a nuclear-localized E3 ubiquitin ligase. The encoded protein can promote tumor formation by targeting tumor suppressor proteins, such as p53, for proteasomal degradation. This gene is itself transcriptionally-regulated by p53. Overexpression or amplification of this locus is detected in a variety of different cancers. There is a pseudogene for this gene on chromosome 2. Alternative splicing results in a multitude of transcript variants, many of which may be expressed only in tumor cells. [provided by RefSeq, Jun 2013]",
-		"aliasName": [
+		"aliases": [
 			"E3 ubiquitin-protein ligase Mdm2",
 			"MDM2 oncogene, E3 ubiquitin protein ligase",
 			"MDM2 proto-oncogene, E3 ubiquitin protein ligase",
@@ -21,7 +21,7 @@ const validResult = {
 			"double minute 2, human homolog of; p53-binding protein",
 			"oncoprotein Mdm2"
 		],
-		"aliasId": [
+		"aliasIds": [
 			"ACTFS",
 			"HDMX",
 			"hdm2"
@@ -37,7 +37,7 @@ const validResult = {
 		"displayName": "tumor protein p53",
 		"localID": "7157",
 		"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
-		"aliasName": [
+		"aliases": [
 			"cellular tumor antigen p53",
 			"antigen NY-CO-13",
 			"mutant tumor protein 53",
@@ -47,7 +47,7 @@ const validResult = {
 			"tumor protein 53",
 			"tumor supressor p53"
 		],
-		"aliasId": [
+		"aliasIds": [
 			"BCC7",
 			"LFS1",
 			"P53",
@@ -67,10 +67,10 @@ const validResult_prefixed_HGNC = {
 		"displayName": "tumor protein p53",
 		"localID": "TP53",
 		"description": "",
-		"aliasName": [
+		"aliases": [
 			"Li-Fraumeni syndrome"
 		],
-		"aliasId": [
+		"aliasIds": [
 			"p53",
 			"LFS1"
 		],
@@ -88,12 +88,12 @@ const validResult_prefixed_UNIPROT = {
 		"displayName": "Cellular tumor antigen p53",
 		"localID": "P04637",
 		"description": "Acts as a tumor suppressor in many tumor types; induces growth arrest or apoptosis depending on the physiological circumstances and cell type. Involved in cell cycle regulation as a trans-activator that acts to negatively regulate cell division by controlling a set of genes required for this process. One of the activated genes is an inhibitor of cyclin-dependent kinases. Apoptosis induction seems to be mediated either by stimulation of BAX and FAS antigen expression, or by repression of Bcl-2 expression. In cooperation with mitochondrial PPIF is involved in activating oxidative stress-induced necrosis; the function is largely independent of transcription. Induces the transcription of long intergenic non-coding RNA p21 (lincRNA-p21) and lincRNA-Mkln1. LincRNA-p21 participates in TP53-dependent transcriptional repression leading to apoptosis and seems to have an effect on cell-cycle regulation. Implicated in Notch signaling cross-over. Prevents CDK7 kinase activity when associated to CAK complex in response to DNA damage, thus stopping cell cycle progression. Isoform 2 enhances the transactivation activity of isoform 1 from some but not all TP53-inducible promoters. Isoform 4 suppresses transactivation activity and impairs growth suppression mediated by isoform 1. Isoform 7 inhibits isoform 1-mediated apoptosis. Regulates the circadian clock by repressing CLOCK-ARNTL/BMAL1-mediated transcriptional activation of PER2 (PubMed:24051492)",
-		"aliasName": [
+		"aliases": [
 			"Antigen NY-CO-13",
 			"Phosphoprotein p53",
 			"Tumor suppressor p53"
 		],
-		"aliasId": [],
+		"aliasIds": [],
 		"xref": {
 			"http://identifiers.org/ncbigene/": "7157",
 			"http://identifiers.org/hgnc/": "TP53",
@@ -108,7 +108,7 @@ const validResult_NCBIGENE = {
 		"displayName": "MDM2 proto-oncogene",
 		"localID": "4193",
 		"description": "This gene encodes a nuclear-localized E3 ubiquitin ligase. The encoded protein can promote tumor formation by targeting tumor suppressor proteins, such as p53, for proteasomal degradation. This gene is itself transcriptionally-regulated by p53. Overexpression or amplification of this locus is detected in a variety of different cancers. There is a pseudogene for this gene on chromosome 2. Alternative splicing results in a multitude of transcript variants, many of which may be expressed only in tumor cells. [provided by RefSeq, Jun 2013]",
-		"aliasName": [
+		"aliases": [
 			"E3 ubiquitin-protein ligase Mdm2",
 			"MDM2 oncogene, E3 ubiquitin protein ligase",
 			"MDM2 proto-oncogene, E3 ubiquitin protein ligase",
@@ -117,7 +117,7 @@ const validResult_NCBIGENE = {
 			"double minute 2, human homolog of; p53-binding protein",
 			"oncoprotein Mdm2"
 		],
-		"aliasId": [
+		"aliasIds": [
 			"ACTFS",
 			"HDMX",
 			"hdm2"
@@ -132,7 +132,7 @@ const validResult_NCBIGENE = {
 		"displayName": "tumor protein p53",
 		"localID": "7157",
 		"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
-		"aliasName": [
+		"aliases": [
 			"cellular tumor antigen p53",
 			"antigen NY-CO-13",
 			"mutant tumor protein 53",
@@ -142,7 +142,7 @@ const validResult_NCBIGENE = {
 			"tumor protein 53",
 			"tumor supressor p53"
 		],
-		"aliasId": [
+		"aliasIds": [
 			"BCC7",
 			"LFS1",
 			"P53",
@@ -161,10 +161,10 @@ const validResult_HGNC = {
 		"displayName":"tumor protein p53",
 		"localID":"TP53",
 		"description":"",
-		"aliasName":[
+		"aliases":[
 			"Li-Fraumeni syndrome"
 		],
-		"aliasId":[
+		"aliasIds":[
 			"p53",
 			"LFS1"
 		],
@@ -179,9 +179,9 @@ const validResult_HGNC = {
 		"displayName":"MDM2 proto-oncogene",
 		"localID":"MDM2",
 		"description":"",
-		"aliasName":[
+		"aliases":[
 		],
-		"aliasId":[
+		"aliasIds":[
 			"HDM2",
 			"MGC5370"
 		],
@@ -199,12 +199,12 @@ const validResult_UNIPROT = {
 		"displayName":"Cellular tumor antigen p53",
 		"localID":"P04637",
 		"description":"Acts as a tumor suppressor in many tumor types; induces growth arrest or apoptosis depending on the physiological circumstances and cell type. Involved in cell cycle regulation as a trans-activator that acts to negatively regulate cell division by controlling a set of genes required for this process. One of the activated genes is an inhibitor of cyclin-dependent kinases. Apoptosis induction seems to be mediated either by stimulation of BAX and FAS antigen expression, or by repression of Bcl-2 expression. In cooperation with mitochondrial PPIF is involved in activating oxidative stress-induced necrosis; the function is largely independent of transcription. Induces the transcription of long intergenic non-coding RNA p21 (lincRNA-p21) and lincRNA-Mkln1. LincRNA-p21 participates in TP53-dependent transcriptional repression leading to apoptosis and seems to have an effect on cell-cycle regulation. Implicated in Notch signaling cross-over. Prevents CDK7 kinase activity when associated to CAK complex in response to DNA damage, thus stopping cell cycle progression. Isoform 2 enhances the transactivation activity of isoform 1 from some but not all TP53-inducible promoters. Isoform 4 suppresses transactivation activity and impairs growth suppression mediated by isoform 1. Isoform 7 inhibits isoform 1-mediated apoptosis. Regulates the circadian clock by repressing CLOCK-ARNTL/BMAL1-mediated transcriptional activation of PER2 (PubMed:24051492)",
-		"aliasName":[
+		"aliases":[
 			"Antigen NY-CO-13",
 			"Phosphoprotein p53",
 			"Tumor suppressor p53"
 		],
-		"aliasId":[
+		"aliasIds":[
 
 		],
 		"xref":{
@@ -218,13 +218,13 @@ const validResult_UNIPROT = {
 		"displayName":"E3 ubiquitin-protein ligase Mdm2",
 		"localID":"Q00987",
 		"description":"E3 ubiquitin-protein ligase that mediates ubiquitination of p53/TP53, leading to its degradation by the proteasome. Inhibits p53/TP53- and p73/TP73-mediated cell cycle arrest and apoptosis by binding its transcriptional activation domain. Also acts as a ubiquitin ligase E3 toward itself and ARRB1. Permits the nuclear export of p53/TP53. Promotes proteasome-dependent ubiquitin-independent degradation of retinoblastoma RB1 protein. Inhibits DAXX-mediated apoptosis by inducing its ubiquitination and degradation. Component of the TRIM28/KAP1-MDM2-p53/TP53 complex involved in stabilizing p53/TP53. Also component of the TRIM28/KAP1-ERBB4-MDM2 complex which links growth factor and DNA damage response pathways. Mediates ubiquitination and subsequent proteasome degradation of DYRK2 in nucleus. Ubiquitinates IGF1R and SNAI1 and promotes them to proteasomal degradation (PubMed:12821780, PubMed:15053880, PubMed:15195100, PubMed:15632057, PubMed:16337594, PubMed:17290220, PubMed:19098711, PubMed:19219073, PubMed:19837670, PubMed:19965871, PubMed:20173098, PubMed:20385133, PubMed:20858735, PubMed:22128911). Ubiquitinates DCX, leading to DCX degradation and reduction of the dendritic spine density of olfactory bulb granule cells (By similarity). Ubiquitinates DLG4, leading to proteasomal degradation of DLG4 which is required for AMPA receptor endocytosis",
-		"aliasName":[
+		"aliases":[
 			"Double minute 2 protein",
 			"Oncoprotein Mdm2",
 			"RING-type E3 ubiquitin transferase Mdm2",
 			"p53-binding protein Mdm2"
 		],
-		"aliasId":[
+		"aliasIds":[
 
 		],
 		"xref":{


### PR DESCRIPTION
Refs #1104, part one.

- simple model/definition for 'entity summary' 
- external services for fetch from HGNC, NCBI Gene and UniProt 
- service to create summaries from query string (q):
  - example for `q=tp53 is an important gene`

```json
{
	"tp53": {
		"dataSource": "http://identifiers.org/ncbigene/",
		"displayName": "tumor protein p53",
		"localID": "7157",
		"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
		"aliasName": [
			"cellular tumor antigen p53",
			"antigen NY-CO-13",
			"mutant tumor protein 53",
			"p53 tumor suppressor",
			"phosphoprotein p53",
			"transformation-related protein 53",
			"tumor protein 53",
			"tumor supressor p53"
		],
		"aliasId": [
			"BCC7",
			"LFS1",
			"P53",
			"TRP53"
		],
		"xref": {
			"http://identifiers.org/hgnc/": "TP53",
			"http://identifiers.org/genecards/": "TP53",
			"http://identifiers.org/uniprot/": "P04637"
		}
	}
}
```