### PR TITLE
Iss1131 pt1 : Using constants, MIRIAM collection namespaces 

### DIFF
--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -2,6 +2,7 @@ const React = require('react');
 const h = require('react-hyperscript');
 const _ = require('lodash');
 const { ServerAPI } = require('../../services/');
+const { COLLECTION_NAMESPACE_HGNC_SYMBOL } = require('../../../config');
 let Textarea = require('react-textarea-autosize').default;
 
 class TokenInput extends React.Component {
@@ -39,7 +40,7 @@ class TokenInput extends React.Component {
     let tokenList = _.pull(inputBoxContents.split(/\s/g), "");
      ServerAPI.enrichmentAPI({
        query: tokenList,
-       targetDb: "HGNCSYMBOL"
+       targetDb: COLLECTION_NAMESPACE_HGNC_SYMBOL
       }, "validation")
     .then( result => {
       let { unrecognized, alias } = result;

--- a/src/client/features/enrichment/token-input.js
+++ b/src/client/features/enrichment/token-input.js
@@ -2,7 +2,7 @@ const React = require('react');
 const h = require('react-hyperscript');
 const _ = require('lodash');
 const { ServerAPI } = require('../../services/');
-const { COLLECTION_NAMESPACE_HGNC_SYMBOL } = require('../../../config');
+const { NS_HGNC_SYMBOL } = require('../../../config');
 let Textarea = require('react-textarea-autosize').default;
 
 class TokenInput extends React.Component {
@@ -40,7 +40,7 @@ class TokenInput extends React.Component {
     let tokenList = _.pull(inputBoxContents.split(/\s/g), "");
      ServerAPI.enrichmentAPI({
        query: tokenList,
-       targetDb: COLLECTION_NAMESPACE_HGNC_SYMBOL
+       targetDb: NS_HGNC_SYMBOL
       }, "validation")
     .then( result => {
       let { unrecognized, alias } = result;

--- a/src/config.js
+++ b/src/config.js
@@ -23,11 +23,11 @@ let defaults = {
   // factoid specific urls
   FACTOID_URL: 'http://unstable.factoid.baderlab.org/',
   BIOPAX_CONVERTERS_URL: 'http://biopax.baderlab.org/',
-  DATASOURCE_HGNC: 'HGNC', // !!!temporary , will be updated as part of 'identifiers url generation module' https://github.com/PathwayCommons/app-ui/issues/1116
-  DATASOURCE_HGNC_SYMBOL: 'HGNCSYMBOL',
-  DATASOURCE_UNIPROT: 'UNIPROT',
-  DATASOURCE_NCBI_GENE: 'NCBIGENE',
-  DATASOURCE_ENSEMBL: 'ENSEMBL'
+  COLLECTION_NAMESPACE_HGNC: 'hgnc',
+  COLLECTION_NAMESPACE_HGNC_SYMBOL: 'hgnc.symbol',
+  COLLECTION_NAMESPACE_UNIPROT: 'uniprot',
+  COLLECTION_NAMESPACE_NCBI_GENE: 'ncbigene',
+  COLLECTION_NAMESPACE_ENSEMBL: 'ensembl'
 };
 
 let envVars = _.pick( process.env, Object.keys( defaults ) );

--- a/src/config.js
+++ b/src/config.js
@@ -23,11 +23,11 @@ let defaults = {
   // factoid specific urls
   FACTOID_URL: 'http://unstable.factoid.baderlab.org/',
   BIOPAX_CONVERTERS_URL: 'http://biopax.baderlab.org/',
-  COLLECTION_NAMESPACE_HGNC: 'hgnc',
-  COLLECTION_NAMESPACE_HGNC_SYMBOL: 'hgnc.symbol',
-  COLLECTION_NAMESPACE_UNIPROT: 'uniprot',
-  COLLECTION_NAMESPACE_NCBI_GENE: 'ncbigene',
-  COLLECTION_NAMESPACE_ENSEMBL: 'ensembl'
+  NS_HGNC: 'hgnc',
+  NS_HGNC_SYMBOL: 'hgnc.symbol',
+  NS_UNIPROT: 'uniprot',
+  NS_NCBI_GENE: 'ncbigene',
+  NS_ENSEMBL: 'ensembl'
 };
 
 let envVars = _.pick( process.env, Object.keys( defaults ) );

--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -5,18 +5,17 @@ const LRUCache = require('lru-cache');
 
 const cleanUpEntrez = require('../clean-up-entrez');
 const InvalidParamError = require('../../../../server/errors/invalid-param');
-const { GPROFILER_URL, PC_CACHE_MAX_SIZE, DATASOURCE_HGNC, DATASOURCE_HGNC_SYMBOL, DATASOURCE_UNIPROT, DATASOURCE_NCBI_GENE, DATASOURCE_ENSEMBL } = require('../../../../config');
+const { GPROFILER_URL, PC_CACHE_MAX_SIZE, COLLECTION_NAMESPACE_HGNC, COLLECTION_NAMESPACE_HGNC_SYMBOL, COLLECTION_NAMESPACE_UNIPROT, COLLECTION_NAMESPACE_NCBI_GENE, COLLECTION_NAMESPACE_ENSEMBL } = require('../../../../config');
 const cache = require('../../../cache');
 const GCONVERT_URL = GPROFILER_URL + 'gconvert.cgi';
 
-const DATASOURCE_NAMES = [DATASOURCE_HGNC, DATASOURCE_HGNC_SYMBOL, DATASOURCE_UNIPROT, DATASOURCE_NCBI_GENE, DATASOURCE_ENSEMBL];
-const GPROFILER_DATASOURCE_NAMES = {
-  HGNC: 'HGNC_ACC',
-  HGNC_SYMBOL: 'HGNC',
-  UNIPROT: 'UNIPROTSWISSPROT',
-  NCBI_GENE: 'ENTREZGENE_ACC',
-  ENSEMBL: 'ENSG'
-};
+const GPROFILER_COLLECTION_NAMESPACE_MAP = new Map([
+  [COLLECTION_NAMESPACE_HGNC, 'HGNC_ACC'],
+  [COLLECTION_NAMESPACE_HGNC_SYMBOL, 'HGNC'],
+  [COLLECTION_NAMESPACE_UNIPROT, 'UNIPROTSWISSPROT'],
+  [COLLECTION_NAMESPACE_NCBI_GENE, 'ENTREZGENE_ACC'],
+  [COLLECTION_NAMESPACE_ENSEMBL, 'ENSG']
+]);
 
 const resultTemplate = ( unrecognized, duplicate, alias ) => {
   return {
@@ -27,28 +26,9 @@ const resultTemplate = ( unrecognized, duplicate, alias ) => {
 };
 
 const mapTarget = target  => {
-  let mappedTarget;
-
-  switch( target.toUpperCase() ){
-    case DATASOURCE_HGNC:
-      mappedTarget = GPROFILER_DATASOURCE_NAMES.HGNC;
-      break;
-    case DATASOURCE_HGNC_SYMBOL:
-      mappedTarget = GPROFILER_DATASOURCE_NAMES.HGNC_SYMBOL;
-      break;
-    case DATASOURCE_UNIPROT:
-      mappedTarget =  GPROFILER_DATASOURCE_NAMES.UNIPROT;
-      break;
-    case DATASOURCE_NCBI_GENE:
-      mappedTarget =  GPROFILER_DATASOURCE_NAMES.NCBI_GENE;
-      break;
-    case DATASOURCE_ENSEMBL:
-      mappedTarget =  GPROFILER_DATASOURCE_NAMES.ENSEMBL;
-      break;
-    default:
-      mappedTarget = GPROFILER_DATASOURCE_NAMES.HGNC;
-  }
-  return mappedTarget;
+  const gconvertNamespace = GPROFILER_COLLECTION_NAMESPACE_MAP.get( target );
+  if( !gconvertNamespace ) throw new InvalidParamError( 'Unrecognized targetDb' );
+  return gconvertNamespace;
 };
 
 const mapQuery = query => query.join(" ");
@@ -79,9 +59,6 @@ const getForm = ( query, defaultOptions, userOptions ) => {
 
   if ( !Array.isArray( form.query ) ) {
     throw new InvalidParamError( 'Invalid query format' );
-  }
-  if ( !(_.values( DATASOURCE_NAMES )).includes( form.target.toUpperCase() ) ) {
-    throw new InvalidParamError( 'Unrecognized targetDb' );
   }
 
   return mapParams( form );
@@ -133,7 +110,7 @@ const rawValidatorGconvert = ( query, userOptions ) => {
   const defaultOptions = {
     'output': 'mini',
     'organism': 'hsapiens',
-    'target': 'HGNC',
+    'target': COLLECTION_NAMESPACE_HGNC,
     'prefix': 'ENTREZGENE_ACC'
   };
 
@@ -155,5 +132,5 @@ module.exports = { validatorGconvert,
   getForm,
   mapParams,
   gConvertResponseHandler,
-  GPROFILER_DATASOURCE_NAMES
+  GPROFILER_COLLECTION_NAMESPACE_MAP
 };

--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -6,16 +6,16 @@ const logger = require('../../../logger');
 const { fetch } = require('../../../../util');
 const cleanUpEntrez = require('../clean-up-entrez');
 const InvalidParamError = require('../../../../server/errors/invalid-param');
-const { GPROFILER_URL, PC_CACHE_MAX_SIZE, COLLECTION_NAMESPACE_HGNC, COLLECTION_NAMESPACE_HGNC_SYMBOL, COLLECTION_NAMESPACE_UNIPROT, COLLECTION_NAMESPACE_NCBI_GENE, COLLECTION_NAMESPACE_ENSEMBL } = require('../../../../config');
+const { GPROFILER_URL, PC_CACHE_MAX_SIZE, NS_HGNC, NS_HGNC_SYMBOL, NS_UNIPROT, NS_NCBI_GENE, NS_ENSEMBL } = require('../../../../config');
 const cache = require('../../../cache');
 const GCONVERT_URL = GPROFILER_URL + 'gconvert.cgi';
 
-const GPROFILER_COLLECTION_NAMESPACE_MAP = new Map([
-  [COLLECTION_NAMESPACE_HGNC, 'HGNC_ACC'],
-  [COLLECTION_NAMESPACE_HGNC_SYMBOL, 'HGNC'],
-  [COLLECTION_NAMESPACE_UNIPROT, 'UNIPROTSWISSPROT'],
-  [COLLECTION_NAMESPACE_NCBI_GENE, 'ENTREZGENE_ACC'],
-  [COLLECTION_NAMESPACE_ENSEMBL, 'ENSG']
+const GPROFILER_NS_MAP = new Map([
+  [NS_HGNC, 'HGNC_ACC'],
+  [NS_HGNC_SYMBOL, 'HGNC'],
+  [NS_UNIPROT, 'UNIPROTSWISSPROT'],
+  [NS_NCBI_GENE, 'ENTREZGENE_ACC'],
+  [NS_ENSEMBL, 'ENSG']
 ]);
 
 const resultTemplate = ( unrecognized, duplicate, alias ) => {
@@ -27,7 +27,7 @@ const resultTemplate = ( unrecognized, duplicate, alias ) => {
 };
 
 const mapTarget = target  => {
-  const gconvertNamespace = GPROFILER_COLLECTION_NAMESPACE_MAP.get( target );
+  const gconvertNamespace = GPROFILER_NS_MAP.get( target );
   if( !gconvertNamespace ) throw new InvalidParamError( 'Unrecognized targetDb' );
   return gconvertNamespace;
 };
@@ -111,7 +111,7 @@ const rawValidatorGconvert = ( query, userOptions ) => {
   const defaultOptions = {
     'output': 'mini',
     'organism': 'hsapiens',
-    'target': COLLECTION_NAMESPACE_HGNC,
+    'target': NS_HGNC,
     'prefix': 'ENTREZGENE_ACC'
   };
 
@@ -137,5 +137,5 @@ module.exports = { validatorGconvert,
   getForm,
   mapParams,
   gConvertResponseHandler,
-  GPROFILER_COLLECTION_NAMESPACE_MAP
+  GPROFILER_NS_MAP
 };

--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -106,7 +106,7 @@ const gConvertResponseHandler = body =>  {
  * @param { object } userOptions - options
  * @return { object } list of unrecognized, object with duplicated and list of mapped IDs
  */
-const rawValidatorGconvert = async ( query, userOptions ) => {
+const rawValidatorGconvert = ( query, userOptions ) => {
 
   const defaultOptions = {
     'output': 'mini',

--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -115,18 +115,18 @@ const rawValidatorGconvert = ( query, userOptions ) => {
     'prefix': 'ENTREZGENE_ACC'
   };
 
-  try{
-    const form = getForm( query, defaultOptions, userOptions );
-    return fetch( GCONVERT_URL, {
+  return Promise.resolve()
+    .then( () => getForm( query, defaultOptions, userOptions ) )
+    .then( form => fetch( GCONVERT_URL, {
       method: 'post',
       body: qs.stringify( form )
-    })
+    }))
     .then( response => response.text() )
-    .then( gConvertResponseHandler );
-  } catch ( err ) {
-    logger.error(`Gprofiler convert query failed - ${ err }`);
-    throw err;
-  }
+    .then( gConvertResponseHandler )
+    .catch( err => {
+      logger.error(`Error in validatorGconvert - ${err.message}`);
+      throw err;
+    });
 };
 
 const pcCache = LRUCache({ max: PC_CACHE_MAX_SIZE, length: () => 1 });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -59,24 +59,16 @@ app.use('/', require('./routes/'));
 app.use(function (req, res, next) {
   let err = new Error('Not Found');
   err.status = 404;
+
   next(err);
 });
 
-// development error handler
-// will print stacktrace
-if (app.get('env') === 'development') {
-  app.use(function (err, req, res/*, next*/) {
-    res.status(err.status || 500);
-    res.render('error');
-  });
-}
-
-// production error handler
-// no stacktraces leaked to user
-// error page handler
-app.use(function (err, req, res/*, next*/) {
+// on thrown error in route, send http 500 and send just the error text message
+app.use(function (err, req, res, next) {
   res.status(err.status || 500);
-  res.render('error');
+  res.send(err.message);
+
+  next(err);
 });
 
 

--- a/src/server/routes/enrichment/index.js
+++ b/src/server/routes/enrichment/index.js
@@ -2,6 +2,8 @@
 const express = require('express');
 const enrichmentRouter = express.Router();
 const swaggerJSDoc = require('swagger-jsdoc');
+
+const { InvalidParamError } = require('../../errors/invalid-param');
 const { validatorGconvert, enrichment } = require('../../external-services/gprofiler');
 const { generateGraphInfo } = require('./visualization');
 
@@ -83,14 +85,14 @@ enrichmentRouter.get('/docs', ( req, res ) => {
  *           "$ref": "#/definitions/error/validationError"
 */
 // expose a rest endpoint for validation service
-enrichmentRouter.post('/validation', (req, res) => {
+enrichmentRouter.post('/validation', (req, res, next) => {
   const query = req.body.query;
-  const tmpOptions = {};
-  tmpOptions.organism = req.body.organism;
-  tmpOptions.target = req.body.targetDb;
-  validatorGconvert(query, tmpOptions).then(gconvertResult => {
-    res.json(gconvertResult);
-  }).catch( error => res.status( 400 ).send( { "error": error.message } ));
+  const tmpOptions = {
+    target: req.body.targetDb
+  };
+  validatorGconvert(query, tmpOptions)
+    .then( gconvertResult => res.json(gconvertResult))
+    .catch( next );
 });
 
 
@@ -218,14 +220,14 @@ enrichmentRouter.post('/visualization', (req, res) => {
  *             type: string
  *         targetDb:
  *           type: string
- *           description: "Target database nomenclature to convert gene list to\n Default: HGNC"
- *           example: "ENSEMBL"
+ *           description: "MIRIAM collection namespace to map to (see http://identifiers.org/) \n Default: hgnc"
+ *           example: "ensembl"
  *           enum:
- *           - "ENSEMBL"
- *           - "HGNC"
- *           - "HGNCSYMBOL"
- *           - "UNIPROT"
- *           - "NCBIGENE"
+ *           - "ensembl"
+ *           - "hgnc"
+ *           - "hgnc.symbol"
+ *           - "ncbigene"
+ *           - "uniprot"
  *     analysisObj:
  *       type: object
  *       required:

--- a/src/server/routes/enrichment/index.js
+++ b/src/server/routes/enrichment/index.js
@@ -3,7 +3,6 @@ const express = require('express');
 const enrichmentRouter = express.Router();
 const swaggerJSDoc = require('swagger-jsdoc');
 
-const { InvalidParamError } = require('../../errors/invalid-param');
 const { validatorGconvert, enrichment } = require('../../external-services/gprofiler');
 const { generateGraphInfo } = require('./visualization');
 

--- a/src/server/routes/enrichment/index.js
+++ b/src/server/routes/enrichment/index.js
@@ -91,7 +91,7 @@ enrichmentRouter.post('/validation', (req, res, next) => {
     target: req.body.targetDb
   };
   validatorGconvert(query, tmpOptions)
-    .then( gconvertResult => res.json(gconvertResult))
+    .then( result => res.json( result ))
     .catch( next );
 });
 

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -3,7 +3,7 @@ const { validatorGconvert } = require('../../../external-services/gprofiler/gcon
 const { getEntitySummary: getNcbiGeneSummary } = require('../../../external-services/ncbi');
 const { getEntitySummary: getHgncSummary } = require('../../../external-services/hgnc');
 const { getEntitySummary: getUniProtSummary } = require('../../../external-services/uniprot');
-const { COLLECTION_NAMESPACE_NCBI_GENE, COLLECTION_NAMESPACE_UNIPROT } = require('../../../../config');
+const { NS_NCBI_GENE, NS_UNIPROT } = require('../../../../config');
 const { DATASOURCES } = require('../../../../models/entity/summary');
 
 /**
@@ -52,7 +52,7 @@ const entitySearch = async tokens => {
   }
 
   const uniqueTokens = _.uniq( tokens );
-  const { alias } = await validatorGconvert( uniqueTokens, { target: COLLECTION_NAMESPACE_NCBI_GENE } );
+  const { alias } = await validatorGconvert( uniqueTokens, { target: NS_NCBI_GENE } );
   // Duplication of work (src/server/external-services/pathway-commons.js).
   // Could consider a single piece of logic that tokenizes and sends to validator.
 
@@ -61,7 +61,7 @@ const entitySearch = async tokens => {
   const summary = await entityFetch( mappedIds, DATASOURCES.NCBIGENE );
 
   // NCBI Gene won't give UniProt Accession, so gotta go get em
-  const { alias: aliasUniProt } = await validatorGconvert( mappedIds, { target: COLLECTION_NAMESPACE_UNIPROT } );
+  const { alias: aliasUniProt } = await validatorGconvert( mappedIds, { target: NS_UNIPROT } );
 
   // Update the entity summaries
   _.keys( aliasUniProt ).forEach( ncbiId => {

--- a/src/server/routes/summary/entity/index.js
+++ b/src/server/routes/summary/entity/index.js
@@ -3,6 +3,7 @@ const { validatorGconvert } = require('../../../external-services/gprofiler/gcon
 const { getEntitySummary: getNcbiGeneSummary } = require('../../../external-services/ncbi');
 const { getEntitySummary: getHgncSummary } = require('../../../external-services/hgnc');
 const { getEntitySummary: getUniProtSummary } = require('../../../external-services/uniprot');
+const { COLLECTION_NAMESPACE_NCBI_GENE, COLLECTION_NAMESPACE_UNIPROT } = require('../../../../config');
 const { DATASOURCES } = require('../../../../models/entity/summary');
 
 /**
@@ -14,7 +15,7 @@ const { DATASOURCES } = require('../../../../models/entity/summary');
 const entityFetch = async ( localIds, dataSource ) => {
   let eSummary;
   switch ( dataSource ) {
-    case DATASOURCES.HGNC:
+    case DATASOURCES.HGNC: //TODO https://github.com/PathwayCommons/app-ui/issues/1131
       eSummary = await getHgncSummary( localIds );
       break;
     case DATASOURCES.UNIPROT:
@@ -51,7 +52,7 @@ const entitySearch = async tokens => {
   }
 
   const uniqueTokens = _.uniq( tokens );
-  const { alias } = await validatorGconvert( uniqueTokens, { target: 'NCBIGene' } );
+  const { alias } = await validatorGconvert( uniqueTokens, { target: COLLECTION_NAMESPACE_NCBI_GENE } );
   // Duplication of work (src/server/external-services/pathway-commons.js).
   // Could consider a single piece of logic that tokenizes and sends to validator.
 
@@ -60,7 +61,7 @@ const entitySearch = async tokens => {
   const summary = await entityFetch( mappedIds, DATASOURCES.NCBIGENE );
 
   // NCBI Gene won't give UniProt Accession, so gotta go get em
-  const { alias: aliasUniProt } = await validatorGconvert( mappedIds, { target: 'UniProt' } );
+  const { alias: aliasUniProt } = await validatorGconvert( mappedIds, { target: COLLECTION_NAMESPACE_UNIPROT } );
 
   // Update the entity summaries
   _.keys( aliasUniProt ).forEach( ncbiId => {

--- a/src/server/routes/summary/index.js
+++ b/src/server/routes/summary/index.js
@@ -2,11 +2,11 @@ const express = require('express');
 const router = express.Router();
 const { entitySearch } = require('./entity');
 
-router.get('/entity/search', function (req, res) {
+router.get('/entity/search', function (req, res, next) {
   let tokens = req.query.q.trim().split(' ');
   entitySearch( tokens )
     .then( r => res.json( r ) )
-    .catch( e => res.status( 500 ).end( "Server error" ) );  // eslint-disable-line no-unused-vars
+    .catch( next );
 });
 
 module.exports = router;

--- a/test/server/enrichment/validation/validation-test.js
+++ b/test/server/enrichment/validation/validation-test.js
@@ -4,8 +4,8 @@ const fs = require ('fs');
 const path = require ('path');
 const _ = require('lodash');
 
-const { COLLECTION_NAMESPACE_HGNC, COLLECTION_NAMESPACE_HGNC_SYMBOL, COLLECTION_NAMESPACE_UNIPROT, COLLECTION_NAMESPACE_NCBI_GENE, COLLECTION_NAMESPACE_ENSEMBL } = require('../../../../src/config');
-const { getForm, mapParams, gConvertResponseHandler, GPROFILER_COLLECTION_NAMESPACE_MAP } = require ('../../../../src/server/external-services/gprofiler/gconvert');
+const { NS_HGNC, NS_HGNC_SYMBOL, NS_UNIPROT, NS_NCBI_GENE, NS_ENSEMBL } = require('../../../../src/config');
+const { getForm, mapParams, gConvertResponseHandler, GPROFILER_NS_MAP } = require ('../../../../src/server/external-services/gprofiler/gconvert');
 const InvalidParamError = require('../../../../src/server/errors/invalid-param');
 
 const query1 = [
@@ -20,12 +20,12 @@ const query1 = [
 const defaultOptions = {
   'output': 'mini',
   'organism': 'hsapiens',
-  'target': COLLECTION_NAMESPACE_HGNC,
+  'target': NS_HGNC,
   'prefix': 'ENTREZGENE_ACC'
 };
 
 const userOptions = {
-  'target': COLLECTION_NAMESPACE_HGNC_SYMBOL
+  'target': NS_HGNC_SYMBOL
 };
 
 const validResult1 = {
@@ -53,7 +53,7 @@ describe ('Enrichment service: validation', function () {
   describe ('Test mapParams ()', function () {
     const baseParams = {
       'query': query1,
-      'target': COLLECTION_NAMESPACE_HGNC,
+      'target': NS_HGNC,
       'organism': 'hsapiens'
     };
 
@@ -63,33 +63,33 @@ describe ('Enrichment service: validation', function () {
     });
 
     it ('should map name for HGNC Symbol', function () {
-      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_HGNC_SYMBOL } );
+      const params = _.assign( {}, baseParams, { 'target': NS_HGNC_SYMBOL } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC_SYMBOL) );
+      expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_HGNC_SYMBOL) );
     });
 
     it ('should map name for HGNC', function () {
-      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_HGNC } );
+      const params = _.assign( {}, baseParams, { 'target': NS_HGNC } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC) );
+      expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_HGNC) );
     });
 
     it ('should map name for UniProt', function () {
-      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_UNIPROT } );
+      const params = _.assign( {}, baseParams, { 'target': NS_UNIPROT } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_UNIPROT) );
+      expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_UNIPROT) );
     });
 
     it ('should map name for NCBI Gene', function () {
-      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_NCBI_GENE } );
+      const params = _.assign( {}, baseParams, { 'target': NS_NCBI_GENE } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_NCBI_GENE) );
+      expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_NCBI_GENE) );
     });
 
     it ('should map name for Ensembl Gene', function () {
-      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_ENSEMBL } );
+      const params = _.assign( {}, baseParams, { 'target': NS_ENSEMBL } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_ENSEMBL) );
+      expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_ENSEMBL) );
     });
 
   });
@@ -99,7 +99,7 @@ describe ('Enrichment service: validation', function () {
       const result = getForm( query1, defaultOptions, {} );
       const expected = _.assign( {}, defaultOptions, {
         query: query1.join (" "),
-        target: GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC)
+        target: GPROFILER_NS_MAP.get(NS_HGNC)
       });
       expect( result ).to.deep.equal( expected );
     });
@@ -108,7 +108,7 @@ describe ('Enrichment service: validation', function () {
       const result = getForm( query1, defaultOptions, userOptions);
       const expected = _.assign( {}, defaultOptions, {
         query: query1.join (" "),
-        target: GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC_SYMBOL)
+        target: GPROFILER_NS_MAP.get(NS_HGNC_SYMBOL)
       });
       expect( result ).to.deep.equal( expected );
     });

--- a/test/server/enrichment/validation/validation-test.js
+++ b/test/server/enrichment/validation/validation-test.js
@@ -4,8 +4,8 @@ const fs = require ('fs');
 const path = require ('path');
 const _ = require('lodash');
 
-const { DATASOURCE_HGNC, DATASOURCE_HGNC_SYMBOL, DATASOURCE_UNIPROT, DATASOURCE_NCBI_GENE, DATASOURCE_ENSEMBL } = require('../../../../src/config');
-const { getForm, mapParams, gConvertResponseHandler, GPROFILER_DATASOURCE_NAMES } = require ('../../../../src/server/external-services/gprofiler/gconvert');
+const { COLLECTION_NAMESPACE_HGNC, COLLECTION_NAMESPACE_HGNC_SYMBOL, COLLECTION_NAMESPACE_UNIPROT, COLLECTION_NAMESPACE_NCBI_GENE, COLLECTION_NAMESPACE_ENSEMBL } = require('../../../../src/config');
+const { getForm, mapParams, gConvertResponseHandler, GPROFILER_COLLECTION_NAMESPACE_MAP } = require ('../../../../src/server/external-services/gprofiler/gconvert');
 const InvalidParamError = require('../../../../src/server/errors/invalid-param');
 
 const query1 = [
@@ -20,12 +20,12 @@ const query1 = [
 const defaultOptions = {
   'output': 'mini',
   'organism': 'hsapiens',
-  'target': DATASOURCE_HGNC,
+  'target': COLLECTION_NAMESPACE_HGNC,
   'prefix': 'ENTREZGENE_ACC'
 };
 
 const userOptions = {
-  'target': DATASOURCE_HGNC_SYMBOL
+  'target': COLLECTION_NAMESPACE_HGNC_SYMBOL
 };
 
 const validResult1 = {
@@ -53,7 +53,7 @@ describe ('Enrichment service: validation', function () {
   describe ('Test mapParams ()', function () {
     const baseParams = {
       'query': query1,
-      'target': 'HGNCSYMBOL',
+      'target': COLLECTION_NAMESPACE_HGNC,
       'organism': 'hsapiens'
     };
 
@@ -63,33 +63,33 @@ describe ('Enrichment service: validation', function () {
     });
 
     it ('should map name for HGNC Symbol', function () {
-      const params = _.assign( {}, baseParams, { 'target': DATASOURCE_HGNC_SYMBOL } );
+      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_HGNC_SYMBOL } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_DATASOURCE_NAMES.HGNC_SYMBOL );
+      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC_SYMBOL) );
     });
 
-    it ('should map name for HGNC Symbol', function () {
-      const params = _.assign( {}, baseParams, { 'target': DATASOURCE_HGNC } );
+    it ('should map name for HGNC', function () {
+      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_HGNC } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_DATASOURCE_NAMES.HGNC );
+      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC) );
     });
 
     it ('should map name for UniProt', function () {
-      const params = _.assign( {}, baseParams, { 'target': DATASOURCE_UNIPROT } );
+      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_UNIPROT } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_DATASOURCE_NAMES.UNIPROT );
+      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_UNIPROT) );
     });
 
     it ('should map name for NCBI Gene', function () {
-      const params = _.assign( {}, baseParams, { 'target': DATASOURCE_NCBI_GENE } );
+      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_NCBI_GENE } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_DATASOURCE_NAMES.NCBI_GENE );
+      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_NCBI_GENE) );
     });
 
     it ('should map name for Ensembl Gene', function () {
-      const params = _.assign( {}, baseParams, { 'target': DATASOURCE_ENSEMBL } );
+      const params = _.assign( {}, baseParams, { 'target': COLLECTION_NAMESPACE_ENSEMBL } );
       const result = mapParams( params );
-      expect( result.target ).to.equal( GPROFILER_DATASOURCE_NAMES.ENSEMBL );
+      expect( result.target ).to.equal( GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_ENSEMBL) );
     });
 
   });
@@ -99,7 +99,7 @@ describe ('Enrichment service: validation', function () {
       const result = getForm( query1, defaultOptions, {} );
       const expected = _.assign( {}, defaultOptions, {
         query: query1.join (" "),
-        target: GPROFILER_DATASOURCE_NAMES.HGNC
+        target: GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC)
       });
       expect( result ).to.deep.equal( expected );
     });
@@ -108,7 +108,7 @@ describe ('Enrichment service: validation', function () {
       const result = getForm( query1, defaultOptions, userOptions);
       const expected = _.assign( {}, defaultOptions, {
         query: query1.join (" "),
-        target: GPROFILER_DATASOURCE_NAMES.HGNC_SYMBOL
+        target: GPROFILER_COLLECTION_NAMESPACE_MAP.get(COLLECTION_NAMESPACE_HGNC_SYMBOL)
       });
       expect( result ).to.deep.equal( expected );
     });


### PR DESCRIPTION
- refs #1131: Basically using config constants for database data collections everywhere in the validation code, tests and the code on client / server that eventually calls `validatorGconvert` with a `target` parameter
- added-back  code by @maxkfranz  for express middleware error handling
  - related simplifications of express endpoint `catch` handlers 