### PR TITLE
Changing cache delete syntax

### DIFF
--- a/src/server/external-services/pathway-commons.js
+++ b/src/server/external-services/pathway-commons.js
@@ -162,7 +162,7 @@ const getEntityUriParts = ( name, localId ) => {
     let res = fetchEntityUriBase( name, localId );
     pcCache.set( name, res );
     res.catch( err => {
-      pcCache.del( name );
+      pcCache.delete( name );
       logger.error(`Failed to fill cache with ${name} and ${localId} - ${err}`);
     });
     return res;


### PR DESCRIPTION
refs #1139 - using quick-lru has `delete()` function.