### PR TITLE
Iss1132 entity summary updates

### DIFF
--- a/src/models/entity/summary.js
+++ b/src/models/entity/summary.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const DEFAULTS = {
   namespace: '',
   displayName: '',
-  localID: '',
+  localId: '',
   description: '',
   aliases: [],
   aliasIds: [],

--- a/src/models/entity/summary.js
+++ b/src/models/entity/summary.js
@@ -1,22 +1,14 @@
 // Entity summary
 const _ = require('lodash');
 
-//To be moved and integrated with all the other 'datasource'
-const DATASOURCES = {
-  NCBIGENE: 'http://identifiers.org/ncbigene/',
-  HGNC: 'http://identifiers.org/hgnc/',
-  UNIPROT: 'http://identifiers.org/uniprot/',
-  GENECARDS: 'http://identifiers.org/genecards/'
-};
-
 const DEFAULTS = {
-  dataSource: '',
+  namespace: '',
   displayName: '',
   localID: '',
   description: '',
   aliases: [],
   aliasIds: [],
-  xref: {}
+  xrefLinks: []
 };
 
 class EntitySummary {
@@ -25,4 +17,4 @@ class EntitySummary {
   }
 }
 
-module.exports = { EntitySummary, DATASOURCES };
+module.exports = { EntitySummary };

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -60,7 +60,7 @@ const getEntitySummary = async symbols => {
     const eSummary = new EntitySummary({
       namespace: NS_HGNC_SYMBOL,
       displayName: _.get( doc, 'name', ''),
-      localID: symbol,
+      localId: symbol,
       aliases: _.get( doc, 'alias_name', []),
       aliasIds:_.get( doc, 'alias_symbol', []),
       xrefLinks: xrefLinks

--- a/src/server/external-services/hgnc.js
+++ b/src/server/external-services/hgnc.js
@@ -66,10 +66,7 @@ const getEntitySummary = async symbols => {
       xrefLinks: xrefLinks
     });
 
-    summary.push({
-      "query": symbol,
-      "entitySummary": eSummary
-    });
+    summary.push(eSummary);
   });
 
   return summary;

--- a/src/server/external-services/ncbi.js
+++ b/src/server/external-services/ncbi.js
@@ -120,10 +120,7 @@ const getEntitySummary = async ( uids ) => {
       xrefLinks: xrefLinks
     });
 
-    summary.push({
-      "query": uid,
-      "entitySummary": eSummary
-    });
+    summary.push(eSummary);
   });
 
   return summary;

--- a/src/server/external-services/ncbi.js
+++ b/src/server/external-services/ncbi.js
@@ -113,7 +113,7 @@ const getEntitySummary = async ( uids ) => {
     const eSummary = new EntitySummary({
       namespace: NS_NCBI_GENE,
       displayName: _.get( doc, 'description', ''),
-      localID: uid,
+      localId: uid,
       description: _.get( doc, 'summary', ''),
       aliases: _.get( doc, 'otherdesignations', '').split('|'),
       aliasIds: _.get( doc, 'otheraliases', '').split(',').map( a => a.trim() ),

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -1,5 +1,5 @@
 const { fetch } = require('../../util');
-const { UNIPROT_API_BASE_URL } = require('../../config');
+const { UNIPROT_API_BASE_URL, NS_GENECARDS, NS_HGNC_SYMBOL, NS_NCBI_GENE, NS_UNIPROT, IDENTIFIERS_URL } = require('../../config');
 const _ = require('lodash');
 const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
 const logger = require('../logger');
@@ -18,9 +18,11 @@ const fetchByAccessions = ( accessions ) => {
     });
 };
 
+const createUri = ( namespace, localId ) => IDENTIFIERS_URL + '/' + namespace + '/' + localId;
+
 const getEntitySummary = async ( accessions ) => {
 
-  const summary = {};
+  const summary = [];
   if ( _.isEmpty( accessions ) ) return summary;
 
   const results = await fetchByAccessions( accessions );
@@ -28,29 +30,47 @@ const getEntitySummary = async ( accessions ) => {
 
   results.forEach( doc => {
 
-    // Fetch external database links first
-    const xref = {};
+    const accession = _.get( doc, 'accession', '');
+
+    // Create external database links first
+    const xrefLinks = [{
+      "namespace": NS_UNIPROT,
+      "uri": createUri( NS_UNIPROT, accession )
+    }];
     doc.dbReferences.forEach( xrf => {
-      if ( xrf.type === 'GeneID' ) {
-        xref[DATASOURCES.NCBIGENE] = _.get( xrf, 'id', '');
-      }
-      if ( xrf.type === 'HGNC' ) {
-        xref[DATASOURCES.HGNC] = _.get( xrf, "properties['gene designation']");
-        xref[DATASOURCES.GENECARDS] = _.get( xrf, "properties['gene designation']");
+      switch ( xrf.type ){
+        case 'HGNC':
+          xrefLinks.push({
+            "namespace": NS_GENECARDS,
+            "uri": createUri( NS_GENECARDS, _.get( xrf, "properties['gene designation']" ) )
+          });
+          xrefLinks.push({
+            "namespace": NS_HGNC_SYMBOL,
+            "uri": createUri( NS_HGNC_SYMBOL, _.get( xrf, "properties['gene designation']" ) )
+          });
+          break;
+        case 'GeneID':
+          xrefLinks.push({
+            "namespace": NS_NCBI_GENE,
+            "uri": createUri( NS_NCBI_GENE, _.get( xrf, 'id', '') )
+          });
+          break;
       }
     });
-    const accession = _.get( doc, 'accession', '');
     const eSummary = new EntitySummary({
-      dataSource: DATASOURCES.UNIPROT,
+      namespace: NS_UNIPROT,
       displayName: _.get( doc, 'protein.recommendedName.fullName.value', ''),
       localID: accession,
       description: _.get( doc, 'comments[0].text[0].value', ''),
       aliases: _.get( doc, 'protein.alternativeName', []).map( elt =>  _.get( elt, 'fullName.value') ),
       aliasIds: _.get( doc, 'protein.recommendedName.shortName', []).map( elt =>  _.get( elt, 'value') ),
-      xref: xref
+      xrefLinks: xrefLinks
     });
 
-    return summary[ accession ] = eSummary;
+    summary.push({
+      "query": accession,
+      "entitySummary": eSummary
+    });
   });
 
   return summary;

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -60,7 +60,7 @@ const getEntitySummary = async ( accessions ) => {
     const eSummary = new EntitySummary({
       namespace: NS_UNIPROT,
       displayName: _.get( doc, 'protein.recommendedName.fullName.value', ''),
-      localID: accession,
+      localId: accession,
       description: _.get( doc, 'comments[0].text[0].value', ''),
       aliases: _.get( doc, 'protein.alternativeName', []).map( elt =>  _.get( elt, 'fullName.value') ),
       aliasIds: _.get( doc, 'protein.recommendedName.shortName', []).map( elt =>  _.get( elt, 'value') ),

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -67,10 +67,7 @@ const getEntitySummary = async ( accessions ) => {
       xrefLinks: xrefLinks
     });
 
-    summary.push({
-      "query": accession,
-      "entitySummary": eSummary
-    });
+    summary.push(eSummary);
   });
 
   return summary;

--- a/src/server/external-services/uniprot.js
+++ b/src/server/external-services/uniprot.js
@@ -1,7 +1,7 @@
 const { fetch } = require('../../util');
 const { UNIPROT_API_BASE_URL, NS_GENECARDS, NS_HGNC_SYMBOL, NS_NCBI_GENE, NS_UNIPROT, IDENTIFIERS_URL } = require('../../config');
 const _ = require('lodash');
-const { EntitySummary, DATASOURCES } = require('../../models/entity/summary');
+const { EntitySummary } = require('../../models/entity/summary');
 const logger = require('../logger');
 
 //Could cache somewhere here.

--- a/test/server/summary/hgnc/entity-summary-TP53.json
+++ b/test/server/summary/hgnc/entity-summary-TP53.json
@@ -1,34 +1,31 @@
 [{
-	"query": "TP53",
-	"entitySummary": {
-		"namespace": "hgnc.symbol",
-		"displayName": "tumor protein p53",
-		"localID": "TP53",
-		"description": "",
-		"aliases": [
-			"Li-Fraumeni syndrome"
-		],
-		"aliasIds": [
-			"p53",
-			"LFS1"
-		],
-		"xrefLinks": [
-			{
-				"namespace": "genecards",
-				"uri": "http://identifiers.org/genecards/TP53"
-			},
-			{
-				"namespace": "hgnc.symbol",
-				"uri": "http://identifiers.org/hgnc.symbol/TP53"
-			},
-			{
-				"namespace": "ncbigene",
-				"uri": "http://identifiers.org/ncbigene/7157"
-			},
-			{
-				"namespace": "uniprot",
-				"uri": "http://identifiers.org/uniprot/P04637"
-			}
-		]
-	}
+	"namespace": "hgnc.symbol",
+	"displayName": "tumor protein p53",
+	"localID": "TP53",
+	"description": "",
+	"aliases": [
+		"Li-Fraumeni syndrome"
+	],
+	"aliasIds": [
+		"p53",
+		"LFS1"
+	],
+	"xrefLinks": [
+		{
+			"namespace": "genecards",
+			"uri": "http://identifiers.org/genecards/TP53"
+		},
+		{
+			"namespace": "hgnc.symbol",
+			"uri": "http://identifiers.org/hgnc.symbol/TP53"
+		},
+		{
+			"namespace": "ncbigene",
+			"uri": "http://identifiers.org/ncbigene/7157"
+		},
+		{
+			"namespace": "uniprot",
+			"uri": "http://identifiers.org/uniprot/P04637"
+		}
+	]
 }]

--- a/test/server/summary/hgnc/entity-summary-TP53.json
+++ b/test/server/summary/hgnc/entity-summary-TP53.json
@@ -1,6 +1,7 @@
-{
-	"TP53": {
-		"dataSource": "http://identifiers.org/hgnc/",
+[{
+	"query": "TP53",
+	"entitySummary": {
+		"namespace": "hgnc.symbol",
 		"displayName": "tumor protein p53",
 		"localID": "TP53",
 		"description": "",
@@ -11,10 +12,23 @@
 			"p53",
 			"LFS1"
 		],
-		"xref": {
-			"http://identifiers.org/genecards/": "TP53",
-			"http://identifiers.org/ncbigene/": "7157",
-			"http://identifiers.org/uniprot/": "P04637"
-		}
+		"xrefLinks": [
+			{
+				"namespace": "genecards",
+				"uri": "http://identifiers.org/genecards/TP53"
+			},
+			{
+				"namespace": "hgnc.symbol",
+				"uri": "http://identifiers.org/hgnc.symbol/TP53"
+			},
+			{
+				"namespace": "ncbigene",
+				"uri": "http://identifiers.org/ncbigene/7157"
+			},
+			{
+				"namespace": "uniprot",
+				"uri": "http://identifiers.org/uniprot/P04637"
+			}
+		]
 	}
-}
+}]

--- a/test/server/summary/hgnc/entity-summary-TP53.json
+++ b/test/server/summary/hgnc/entity-summary-TP53.json
@@ -1,7 +1,7 @@
 [{
 	"namespace": "hgnc.symbol",
 	"displayName": "tumor protein p53",
-	"localID": "TP53",
+	"localId": "TP53",
 	"description": "",
 	"aliases": [
 		"Li-Fraumeni syndrome"

--- a/test/server/summary/hgnc/entity-summary-test.js
+++ b/test/server/summary/hgnc/entity-summary-test.js
@@ -21,7 +21,7 @@ describe ('External service: HGNC', function () {
     it('Should return an empty object with no input', async () => {
       global.fetch = mockFetch( { json: () => EMPTY_RESPONSE_DATA_TP53 } );
       const result =  await getEntitySummary( [ 'TTTT' ] );
-      expect( result ).to.deep.equal( {} );
+      expect( result ).to.deep.equal( [] );
     });
 
   });

--- a/test/server/summary/ncbi/entity-summary-7157.json
+++ b/test/server/summary/ncbi/entity-summary-7157.json
@@ -1,6 +1,7 @@
-{
-	"7157": {
-		"dataSource": "http://identifiers.org/ncbigene/",
+[{
+	"query": "7157",
+	"entitySummary": {
+		"namespace": "ncbigene",
 		"displayName": "tumor protein p53",
 		"localID": "7157",
 		"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
@@ -20,9 +21,19 @@
 			"P53",
 			"TRP53"
 		],
-		"xref": {
-			"http://identifiers.org/hgnc/": "TP53",
-			"http://identifiers.org/genecards/": "TP53"
-		}
+		"xrefLinks": [
+			{
+				"namespace": "hgnc.symbol",
+				"uri": "http://identifiers.org/hgnc.symbol/TP53"
+			},
+			{
+				"namespace": "genecards",
+				"uri": "http://identifiers.org/genecards/TP53"
+			},
+			{
+				"namespace": "ncbigene",
+				"uri": "http://identifiers.org/ncbigene/7157"
+			}
+		]
 	}
-}
+}]

--- a/test/server/summary/ncbi/entity-summary-7157.json
+++ b/test/server/summary/ncbi/entity-summary-7157.json
@@ -1,39 +1,36 @@
 [{
-	"query": "7157",
-	"entitySummary": {
-		"namespace": "ncbigene",
-		"displayName": "tumor protein p53",
-		"localID": "7157",
-		"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
-		"aliases": [
-			"cellular tumor antigen p53",
-			"antigen NY-CO-13",
-			"mutant tumor protein 53",
-			"p53 tumor suppressor",
-			"phosphoprotein p53",
-			"transformation-related protein 53",
-			"tumor protein 53",
-			"tumor supressor p53"
-		],
-		"aliasIds": [
-			"BCC7",
-			"LFS1",
-			"P53",
-			"TRP53"
-		],
-		"xrefLinks": [
-			{
-				"namespace": "hgnc.symbol",
-				"uri": "http://identifiers.org/hgnc.symbol/TP53"
-			},
-			{
-				"namespace": "genecards",
-				"uri": "http://identifiers.org/genecards/TP53"
-			},
-			{
-				"namespace": "ncbigene",
-				"uri": "http://identifiers.org/ncbigene/7157"
-			}
-		]
-	}
+	"namespace": "ncbigene",
+	"displayName": "tumor protein p53",
+	"localID": "7157",
+	"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
+	"aliases": [
+		"cellular tumor antigen p53",
+		"antigen NY-CO-13",
+		"mutant tumor protein 53",
+		"p53 tumor suppressor",
+		"phosphoprotein p53",
+		"transformation-related protein 53",
+		"tumor protein 53",
+		"tumor supressor p53"
+	],
+	"aliasIds": [
+		"BCC7",
+		"LFS1",
+		"P53",
+		"TRP53"
+	],
+	"xrefLinks": [
+		{
+			"namespace": "hgnc.symbol",
+			"uri": "http://identifiers.org/hgnc.symbol/TP53"
+		},
+		{
+			"namespace": "genecards",
+			"uri": "http://identifiers.org/genecards/TP53"
+		},
+		{
+			"namespace": "ncbigene",
+			"uri": "http://identifiers.org/ncbigene/7157"
+		}
+	]
 }]

--- a/test/server/summary/ncbi/entity-summary-7157.json
+++ b/test/server/summary/ncbi/entity-summary-7157.json
@@ -1,7 +1,7 @@
 [{
 	"namespace": "ncbigene",
 	"displayName": "tumor protein p53",
-	"localID": "7157",
+	"localId": "7157",
 	"description": "This gene encodes a tumor suppressor protein containing transcriptional activation, DNA binding, and oligomerization domains. The encoded protein responds to diverse cellular stresses to regulate expression of target genes, thereby inducing cell cycle arrest, apoptosis, senescence, DNA repair, or changes in metabolism. Mutations in this gene are associated with a variety of human cancers, including hereditary cancers such as Li-Fraumeni syndrome. Alternative splicing of this gene and the use of alternate promoters result in multiple transcript variants and isoforms. Additional isoforms have also been shown to result from the use of alternate translation initiation codons from identical transcript variants (PMIDs: 12032546, 20937277). [provided by RefSeq, Dec 2016]",
 	"aliases": [
 		"cellular tumor antigen p53",

--- a/test/server/summary/ncbi/entity-summary-test.js
+++ b/test/server/summary/ncbi/entity-summary-test.js
@@ -21,7 +21,7 @@ describe ('External service: NCBI', function () {
     it('Should return an empty object with no input', async () => {
       global.fetch = mockFetch( { json: () => EMPTY_RESPONSE_DATA_7157 } );
       const result =  await getEntitySummary( [ '0000' ] );
-      expect( result ).to.deep.equal( {} );
+      expect( result ).to.deep.equal( [] );
     });
 
   });

--- a/test/server/summary/uniprot/entity-summary-Q99988.json
+++ b/test/server/summary/uniprot/entity-summary-Q99988.json
@@ -1,7 +1,7 @@
 [{
 	"namespace": "uniprot",
 	"displayName": "Growth/differentiation factor 15",
-	"localID": "Q99988",
+	"localId": "Q99988",
 	"description": "Regulates food intake, energy expenditure and body weight in response to metabolic and toxin-induced stresses (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099, PubMed:23468844, PubMed:29046435). Binds to its receptor, GFRAL, and activates GFRAL-expressing neurons localized in the area postrema and nucleus tractus solitarius of the brainstem (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099). It then triggers the activation of neurons localized within the parabrachial nucleus and central amygdala, which contitutes part of the 'emergency circuit' that shapes feeding responses to stressful conditions (PubMed:28953886). On hepatocytes, inhibits growth hormone signaling",
 	"aliases": [
 		"Macrophage inhibitory cytokine 1",

--- a/test/server/summary/uniprot/entity-summary-Q99988.json
+++ b/test/server/summary/uniprot/entity-summary-Q99988.json
@@ -1,6 +1,7 @@
-{
-	"Q99988": {
-		"dataSource": "http://identifiers.org/uniprot/",
+[{
+	"query": "Q99988",
+	"entitySummary": {
+		"namespace": "uniprot",
 		"displayName": "Growth/differentiation factor 15",
 		"localID": "Q99988",
 		"description": "Regulates food intake, energy expenditure and body weight in response to metabolic and toxin-induced stresses (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099, PubMed:23468844, PubMed:29046435). Binds to its receptor, GFRAL, and activates GFRAL-expressing neurons localized in the area postrema and nucleus tractus solitarius of the brainstem (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099). It then triggers the activation of neurons localized within the parabrachial nucleus and central amygdala, which contitutes part of the 'emergency circuit' that shapes feeding responses to stressful conditions (PubMed:28953886). On hepatocytes, inhibits growth hormone signaling",
@@ -15,10 +16,23 @@
 		"aliasIds": [
 			"GDF-15"
 		],
-		"xref": {
-			"http://identifiers.org/ncbigene/": "9518",
-			"http://identifiers.org/hgnc/": "GDF15",
-			"http://identifiers.org/genecards/": "GDF15"
-		}
+		"xrefLinks": [
+			{
+				"namespace": "uniprot",
+				"uri": "http://identifiers.org/uniprot/Q99988"
+			},
+			{
+				"namespace": "ncbigene",
+				"uri": "http://identifiers.org/ncbigene/9518"
+			},
+			{
+				"namespace": "genecards",
+				"uri": "http://identifiers.org/genecards/GDF15"
+			},
+			{
+				"namespace": "hgnc.symbol",
+				"uri": "http://identifiers.org/hgnc.symbol/GDF15"
+			}
+		]
 	}
-}
+}]

--- a/test/server/summary/uniprot/entity-summary-Q99988.json
+++ b/test/server/summary/uniprot/entity-summary-Q99988.json
@@ -1,38 +1,35 @@
 [{
-	"query": "Q99988",
-	"entitySummary": {
-		"namespace": "uniprot",
-		"displayName": "Growth/differentiation factor 15",
-		"localID": "Q99988",
-		"description": "Regulates food intake, energy expenditure and body weight in response to metabolic and toxin-induced stresses (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099, PubMed:23468844, PubMed:29046435). Binds to its receptor, GFRAL, and activates GFRAL-expressing neurons localized in the area postrema and nucleus tractus solitarius of the brainstem (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099). It then triggers the activation of neurons localized within the parabrachial nucleus and central amygdala, which contitutes part of the 'emergency circuit' that shapes feeding responses to stressful conditions (PubMed:28953886). On hepatocytes, inhibits growth hormone signaling",
-		"aliases": [
-			"Macrophage inhibitory cytokine 1",
-			"NSAID-activated gene 1 protein",
-			"NSAID-regulated gene 1 protein",
-			"Placental TGF-beta",
-			"Placental bone morphogenetic protein",
-			"Prostate differentiation factor"
-		],
-		"aliasIds": [
-			"GDF-15"
-		],
-		"xrefLinks": [
-			{
-				"namespace": "uniprot",
-				"uri": "http://identifiers.org/uniprot/Q99988"
-			},
-			{
-				"namespace": "ncbigene",
-				"uri": "http://identifiers.org/ncbigene/9518"
-			},
-			{
-				"namespace": "genecards",
-				"uri": "http://identifiers.org/genecards/GDF15"
-			},
-			{
-				"namespace": "hgnc.symbol",
-				"uri": "http://identifiers.org/hgnc.symbol/GDF15"
-			}
-		]
-	}
+	"namespace": "uniprot",
+	"displayName": "Growth/differentiation factor 15",
+	"localID": "Q99988",
+	"description": "Regulates food intake, energy expenditure and body weight in response to metabolic and toxin-induced stresses (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099, PubMed:23468844, PubMed:29046435). Binds to its receptor, GFRAL, and activates GFRAL-expressing neurons localized in the area postrema and nucleus tractus solitarius of the brainstem (PubMed:28953886, PubMed:28846097, PubMed:28846098, PubMed:28846099). It then triggers the activation of neurons localized within the parabrachial nucleus and central amygdala, which contitutes part of the 'emergency circuit' that shapes feeding responses to stressful conditions (PubMed:28953886). On hepatocytes, inhibits growth hormone signaling",
+	"aliases": [
+		"Macrophage inhibitory cytokine 1",
+		"NSAID-activated gene 1 protein",
+		"NSAID-regulated gene 1 protein",
+		"Placental TGF-beta",
+		"Placental bone morphogenetic protein",
+		"Prostate differentiation factor"
+	],
+	"aliasIds": [
+		"GDF-15"
+	],
+	"xrefLinks": [
+		{
+			"namespace": "uniprot",
+			"uri": "http://identifiers.org/uniprot/Q99988"
+		},
+		{
+			"namespace": "ncbigene",
+			"uri": "http://identifiers.org/ncbigene/9518"
+		},
+		{
+			"namespace": "genecards",
+			"uri": "http://identifiers.org/genecards/GDF15"
+		},
+		{
+			"namespace": "hgnc.symbol",
+			"uri": "http://identifiers.org/hgnc.symbol/GDF15"
+		}
+	]
 }]

--- a/test/server/summary/uniprot/entity-summary-test.js
+++ b/test/server/summary/uniprot/entity-summary-test.js
@@ -21,7 +21,7 @@ describe ('External service: UniProt', function () {
     it('Should return an empty object with no input', async () => {
       global.fetch = mockFetch( { json: () => EMPTY_RESPONSE_DATA_Q99988 } );
       const result =  await getEntitySummary( [ 'TTTT' ] );
-      expect( result ).to.deep.equal( {} );
+      expect( result ).to.deep.equal( [] );
     });
 
   });


### PR DESCRIPTION
refs #1132 

- Use config constants  for namespaces
- Renamed EntitySummary model  attributes:
  - `dataSource` --> `namespace`
  - `xref` --> `xrefLinks`
  - `localID` --> `localId`
- `entitySearch()` service returns `{"query": <token>, "summary": <EntitySummary>}` 
- UI update for Summary box