### PR TITLE
Input box attribute typo for maxLength

### DIFF
--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -184,7 +184,7 @@ class Search extends React.Component {
                   type: 'text',
                   placeholder: 'Enter pathway name or gene names',
                   value: state.query.q,
-                  maxlength: 250, // 250 chars max of user input
+                  maxLength: 250, // 250 chars max of user input
                   onChange: e => this.onSearchValueChange(e),
                   onKeyPress: e => this.onSearchValueChange(e)
                 }),


### PR DESCRIPTION
I think this is a React related requirement for camelCasing.

![image](https://user-images.githubusercontent.com/4706307/48632159-2fb7c280-e98e-11e8-92d5-cec50973b5b6.png)
