### PR TITLE
Makes #1193 work once PathwayCommons/factoid#395 works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The following environment variables can be used to configure the server:
 - `NODE_ENV` : the environment mode, either `production` or `development` (default)
 - `PC_URL` : root Pathway Commons URL (default: 'http://www.pathwaycommons.org/')
 - `FACTOID_URL` : the Factoid app URL (default: 'http://unstable.factoid.baderlab.org/')
-- `BIOPAX_CONVERTERS_URL` : the BioPAX/SBGN micro-converter URL (default: 'http://biopax.baderlab.org/convert/v2/')
 - `PORT` : the port on which the server runs (default 3000)
 
 ### Configure RethinkDB

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,6 @@ let defaults = {
   DB_CERT: undefined,
   // factoid specific urls
   FACTOID_URL: 'http://unstable.factoid.baderlab.org/',
-  BIOPAX_CONVERTERS_URL: 'http://biopax.baderlab.org/convert/v2/',
   NS_CHEBI: 'chebi',
   NS_ENSEMBL: 'ensembl',
   NS_GENECARDS: 'genecards',

--- a/src/server/routes/factoids/index.js
+++ b/src/server/routes/factoids/index.js
@@ -17,14 +17,14 @@ let getFactoidJson = ( id ) => {
   .then( res => res.json() );
 };
 
-let getFactoidBiopax = ( id ) => {
-  return new Promise( ( resolve, reject ) => {
-    fetch( FACTOID_URL + 'api/document/biopax/' + id, { method: 'get', accept: 'application/vnd.biopax.rdf+xml'})
-    .then( res => res.text() )
-    .then( resolve )
-    .catch( reject );
-  });
-};
+// let getFactoidBiopax = ( id ) => {
+//   return new Promise( ( resolve, reject ) => {
+//     fetch( FACTOID_URL + 'api/document/biopax/' + id, { method: 'get', accept: 'application/vnd.biopax.rdf+xml'})
+//     .then( res => res.text() )
+//     .then( resolve )
+//     .catch( reject );
+//   });
+// };
 
 let getFactoidSbgn = ( id ) => {
   return new Promise( ( resolve, reject ) => {
@@ -45,7 +45,6 @@ let getFactoidSbgnJson = id => {
     })
   );
 };
-
 
 router.get('/', ( req, res ) => getFactoidIdsJson().then( j => res.json( j ) ) );
 

--- a/src/server/routes/factoids/index.js
+++ b/src/server/routes/factoids/index.js
@@ -3,7 +3,7 @@ const Promise = require('bluebird');
 const { fetch } = require('../../../util');
 const sbgn2CyJson = require('sbgnml-to-cytoscape');
 const _ = require('lodash');
-const { FACTOID_URL, BIOPAX_CONVERTERS_URL } = require('../../../config');
+const { FACTOID_URL } = require('../../../config');
 
 const router = express.Router();
 
@@ -26,29 +26,18 @@ let getFactoidBiopax = ( id ) => {
   });
 };
 
-let biopax2Sbgn = biopax => {
-  return new Promise(( resolve, reject ) => {
-    fetch( BIOPAX_CONVERTERS_URL + 'biopax-to-sbgn', {
-      method: 'post',
-      body: biopax,
-      headers: {
-        'Content-Type': 'application/vnd.biopax.rdf+xml',
-        'Accept': 'application/xml'
-      },
-    })
-    .then( res => res.text() )
-    .then( resolve )
-    .catch( reject );
+let getFactoidSbgn = ( id ) => {
+  return new Promise( ( resolve, reject ) => {
+    fetch( FACTOID_URL + 'api/document/sbgn/' + id, { method: 'get', accept: 'application/xml'})
+      .then( res => res.text() )
+      .then( resolve )
+      .catch( reject );
   });
 };
 
-
 let getFactoidSbgnJson = id => {
   return (
-    getFactoidBiopax( id )
-    .then( biopax => {
-      return biopax2Sbgn( biopax );
-    })
+    getFactoidSbgn( id )
     .then( sbgn => {
       let cyjson = sbgn2CyJson( sbgn );
 


### PR DESCRIPTION
This is to use new factoid api: api/document/sbgn instead of calling the factoid biopax/sbgn converters directly (and having an extra convertion step and config./env. option).