### PR TITLE
Iss1202: Enrichment pathway links

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,7 @@ let defaults = {
   NS_CHEBI: 'chebi',
   NS_ENSEMBL: 'ensembl',
   NS_GENECARDS: 'genecards',
+  NS_GENE_ONTOLOGY: 'go',
   NS_HGNC: 'hgnc',
   NS_HGNC_SYMBOL: 'hgnc.symbol',
   NS_NCBI_GENE: 'ncbigene',

--- a/src/server/external-services/pathway-commons.js
+++ b/src/server/external-services/pathway-commons.js
@@ -3,6 +3,7 @@ const url = require('url');
 const QuickLRU = require('quick-lru');
 const _ = require('lodash');
 
+const InvalidParamError = require('../errors/invalid-param');
 const { cachePromise } = require('../cache');
 const { fetch } = require('../../util');
 const logger = require('../logger');
@@ -95,7 +96,11 @@ const fetchEntityUriBase = ( name, localId ) => {
   const url = config.PC_URL + 'pc2/miriam/uri/' + constructQueryPath( name, localId ) ;
   return fetch( url , { method: 'GET', headers: { 'Accept': 'text/plain' } })
     .then( res => res.text() )
-    .then( handleEntityUriResponse );
+    .then( handleEntityUriResponse )
+    .catch( error => {
+      if( error instanceof TypeError ) throw new InvalidParamError('Unrecognized parameters');
+      throw error;
+    });
 };
 
 const getEntityUriParts = cachePromise(fetchEntityUriBase, xrefCache, name => name);

--- a/src/server/routes/enrichment/visualization/index.js
+++ b/src/server/routes/enrichment/visualization/index.js
@@ -1,10 +1,27 @@
 const _ = require('lodash');
+
 const { pathwayInfoTable } = require('./pathway-table');
+const logger = require('../../../logger');
+const { NS_GENE_ONTOLOGY, NS_REACTOME } = require('../../../../config');
+const { xref2Uri } = require('../../../external-services/pathway-commons');
+
+const isGOId = token => /^GO:\d+$/.test( token );
+const isReactomeId = token => /^R-HSA-\d+$/.test( token );
+const normalizeId = pathwayId => pathwayId.replace('REAC:', '');
+const getXref = id => {
+  let name;
+  if( isGOId( id ) ){
+    name = NS_GENE_ONTOLOGY;
+  } else if ( isReactomeId( id ) ) {
+    name = NS_REACTOME;
+  }
+  return xref2Uri( name, id );
+};
 
 const createEnrichmentNetworkNode = pathwayInfo => {
   let { pathwayId, geneSet, name, intersection } = pathwayInfo;
 
-  return {
+  const node = {
     data: {
       id: pathwayId,
       intersection,
@@ -13,6 +30,14 @@ const createEnrichmentNetworkNode = pathwayInfo => {
       name
     }
   };
+
+  return Promise.resolve( normalizeId( pathwayId ) )
+    .then( getXref )
+    .then( ({ uri, namespace }) => _.assign( node.data, { uri, namespace } ) )
+    .catch( error => {
+      logger.error(`Error in createEnrichmentNetworkNode - ${error}`);
+      throw error;
+    });
 };
 
 // given two genelists, compute the intersection between them
@@ -71,7 +96,7 @@ const createEnrichmentNetworkEdges = (pathwayInfoList, jaccardOverlapWeight, sim
 };
 
 // generate cytoscape.js compatible network JSON for enrichment
-const generateEnrichmentNetworkJson = (pathways, similarityCutoff = 0.375, jaccardOverlapWeight = 0.5) => {
+const generateEnrichmentNetworkJson = async (pathways, similarityCutoff = 0.375, jaccardOverlapWeight = 0.5) => {
   if (similarityCutoff < 0 || similarityCutoff > 1) {
     throw new Error('ERROR: similarityCutoff out of range [0, 1]');
   }
@@ -99,7 +124,8 @@ const generateEnrichmentNetworkJson = (pathways, similarityCutoff = 0.375, jacca
     }
   } );
 
-  let nodes = pathwayInfoList.map( pathwayInfo => createEnrichmentNetworkNode( pathwayInfo ) );
+  let nodePromises = pathwayInfoList.map( async pathwayInfo =>  await createEnrichmentNetworkNode( pathwayInfo ) );
+  const nodes = await Promise.all( nodePromises );
 
   let edges = createEnrichmentNetworkEdges( pathwayInfoList, jaccardOverlapWeight, similarityCutoff );
 

--- a/src/server/routes/enrichment/visualization/index.js
+++ b/src/server/routes/enrichment/visualization/index.js
@@ -41,8 +41,8 @@ const createEnrichmentNetworkNode = pathwayInfo => {
 
   return Promise.resolve( normalizeId( pathwayId ) )
     .then( getXref )
-    .then( ({ uri, namespace }) => {
-      _.assign( node.data, { uri, namespace } );
+    .then( xref => {
+      _.assign( node.data, xref );
       return node;
     })
     .catch( error => {

--- a/src/server/routes/enrichment/visualization/index.js
+++ b/src/server/routes/enrichment/visualization/index.js
@@ -39,7 +39,7 @@ const createEnrichmentNetworkNode = pathwayInfo => {
     })
     .catch( error => {
       logger.error(`Error in createEnrichmentNetworkNode - ${error}`);
-      throw error;
+      return node; // Allow the node through
     });
 };
 

--- a/src/server/routes/enrichment/visualization/index.js
+++ b/src/server/routes/enrichment/visualization/index.js
@@ -33,7 +33,10 @@ const createEnrichmentNetworkNode = pathwayInfo => {
 
   return Promise.resolve( normalizeId( pathwayId ) )
     .then( getXref )
-    .then( ({ uri, namespace }) => _.assign( node.data, { uri, namespace } ) )
+    .then( ({ uri, namespace }) => {
+      _.assign( node.data, { uri, namespace } );
+      return node;
+    })
     .catch( error => {
       logger.error(`Error in createEnrichmentNetworkNode - ${error}`);
       throw error;

--- a/src/server/routes/pathway-commons-router.js
+++ b/src/server/routes/pathway-commons-router.js
@@ -10,11 +10,10 @@ router.get('/search', function (req, res) {
 });
 
 //for debugging
-router.get('/xref2Uri/:name/:localId', function (req, res) {
-  res.set('Content-Type', 'application/json');
+router.get('/xref2Uri/:name/:localId', function (req, res, next) {
   pc.xref2Uri( req.params.name, req.params.localId )
     .then( r => res.json( r ))
-    .catch( err => res.end( err.message ) );
+    .catch( next );
 });
 
 

--- a/src/styles/common/cytoscape-tooltip.css
+++ b/src/styles/common/cytoscape-tooltip.css
@@ -35,7 +35,7 @@
 
 .cy-tooltip-title {
   margin: 0;
-  line-height: 1em;
+  line-height: 1.5em;
   display: inline-block;
 }
 

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,4 +1,4 @@
-const promiseTimeout = require('./promise');
+const { promiseTimeout, TimeoutError } = require('./promise');
 
 const failOnBadStatus = res => {
   if(!res.ok){
@@ -12,4 +12,4 @@ const safeFetch =  ( url, options ) => {
   return promiseTimeout( () => fetch( url, options ).then( failOnBadStatus ) );
 };
 
-module.exports = safeFetch;
+module.exports = { safeFetch, TimeoutError };

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,3 +1,3 @@
-const fetch = require('./fetch');
+const { safeFetch: fetch, TimeoutError } = require('./fetch');
 
-module.exports = { fetch };
+module.exports = { fetch, TimeoutError };

--- a/src/util/promise.js
+++ b/src/util/promise.js
@@ -7,4 +7,7 @@ let promiseTimeout = fn => {
 };
 
 
-module.exports = promiseTimeout;
+module.exports = {
+  promiseTimeout,
+  TimeoutError: Promise.TimeoutError
+};

--- a/test/server/enrichment/visualization/visualization-test.js
+++ b/test/server/enrichment/visualization/visualization-test.js
@@ -1,5 +1,8 @@
 const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const expect = chai.expect;
+chai.use(chaiAsPromised);
+chai.should();
 
 const { mockFetch } = require('../../../util');
 const { generateEnrichmentNetworkJson } = require('../../../../src/server/routes/enrichment/visualization');
@@ -327,18 +330,14 @@ describe('Test generateGraphInfo - Enrichment Vizualization Service', function (
     expect(res).to.deep.equal(result);
   });
 
-  // it('parameters: invalid similarityCutoff', function () {
-  //   chai.assert.throws(function(){
-  //     generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, 3.55 );},
-  //     Error, "similarityCutoff out of range [0, 1]"
-  //   );
-  // });
+  it('parameters: invalid similarityCutoff', () => {
+    const result = generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, 3.55 );
+    return result.should.be.rejectedWith(Error);
+  });
 
-  // it('parameters: invalid jaccardOverlapWeight', function () {
-  //   chai.assert.throws(function(){
-  //     generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, .55, 75 );},
-  //     Error, "jaccardOverlapWeight out of range [0, 1]"
-  //   );
-  // });
+  it('parameters: invalid jaccardOverlapWeight', function () {
+    const result =  generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, .55, 75 );
+    return result.should.be.rejectedWith(Error);
+  });
 
 });

--- a/test/server/enrichment/visualization/visualization-test.js
+++ b/test/server/enrichment/visualization/visualization-test.js
@@ -1,12 +1,15 @@
 const chai = require('chai');
 const expect = chai.expect;
+
+const { mockFetch } = require('../../../util');
 const { generateEnrichmentNetworkJson } = require('../../../../src/server/routes/enrichment/visualization');
 
 //generateGraphInfo( pathways, similarityCutoff, jaccardOverlapWeight);
 
 describe('Test generateGraphInfo - Enrichment Vizualization Service', function () {
-  it('parameters: all valid', function () {
-    const res = generateEnrichmentNetworkJson({"GO:0006354": { "p_value": .1 }, "GO:0006368": { "intersection": ["AFF4"] }}, 0.3, 0.55 );
+  it('parameters: all valid', async () => {
+    global.fetch = mockFetch( { text: () => 'http://identifiers.org/name/id' } );
+    const res = await generateEnrichmentNetworkJson({"GO:0006354": { "p_value": .1 }, "GO:0006368": { "intersection": ["AFF4"] }}, 0.3, 0.55 );
     const result = {
       "unrecognized": [],
       "graph": {
@@ -320,18 +323,18 @@ describe('Test generateGraphInfo - Enrichment Vizualization Service', function (
     expect(res).to.deep.equal(result);
   });
 
-  it('parameters: invalid similarityCutoff', function () {
-    chai.assert.throws(function(){
-      generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, 3.55 );},
-      Error, "similarityCutoff out of range [0, 1]"
-    );
-  });
+  // it('parameters: invalid similarityCutoff', function () {
+  //   chai.assert.throws(function(){
+  //     generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, 3.55 );},
+  //     Error, "similarityCutoff out of range [0, 1]"
+  //   );
+  // });
 
-  it('parameters: invalid jaccardOverlapWeight', function () {
-    chai.assert.throws(function(){
-      generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, .55, 75 );},
-      Error, "jaccardOverlapWeight out of range [0, 1]"
-    );
-  });
+  // it('parameters: invalid jaccardOverlapWeight', function () {
+  //   chai.assert.throws(function(){
+  //     generateEnrichmentNetworkJson({ "GO:0006354": { "p_value": 1 }, "GO:0006368": { "intersection": ["AFF4"] }}, .55, 75 );},
+  //     Error, "jaccardOverlapWeight out of range [0, 1]"
+  //   );
+  // });
 
 });

--- a/test/server/enrichment/visualization/visualization-test.js
+++ b/test/server/enrichment/visualization/visualization-test.js
@@ -119,7 +119,9 @@ describe('Test generateGraphInfo - Enrichment Vizualization Service', function (
                   "ELL2",
                   "GTF2H5"
                 ],
-                "name": "DNA-templated transcription, elongation"
+                "name": "DNA-templated transcription, elongation",
+                "namespace": "name",
+                "uri": "http://identifiers.org/name/GO:0006354"
               }
             },
             {
@@ -216,7 +218,9 @@ describe('Test generateGraphInfo - Enrichment Vizualization Service', function (
                   "WDR61",
                   "POLR2I"
                 ],
-                "name": "transcription elongation from RNA polymerase II promoter"
+                "name": "transcription elongation from RNA polymerase II promoter",
+                "namespace": "name",
+                "uri": "http://identifiers.org/name/GO:0006368"
               }
             }
           ],

--- a/test/server/pathways/pathways-network-generation.js
+++ b/test/server/pathways/pathways-network-generation.js
@@ -31,10 +31,12 @@ function mockFetch(){
   });
 }
 
-global.fetch = mockFetch;
+
 
 describe('Pathways network generation', function(){
+
   it('Should return correct metadata from getBiopaxMetadata', async () => {
+    global.fetch = mockFetch;
     let sampleBiopaxData = fs.readFileSync(path.resolve(__dirname, './sample-biopax-data.txt'), 'utf-8');
 
     let result = await fillInBiopaxMetadata( sampleCyjsonData, sampleBiopaxData );


### PR DESCRIPTION
The only major change is to [server/routes/enrichment/visualization/index.js](https://github.com/PathwayCommons/app-ui/compare/development...jvwong:iss1202_pathway-linkout?expand=1#diff-2f8d7aae9804307468d4fa6ea41b15c2)

- To fetch a url for a pathway
  - reuse our `xref2Uri` service
    - If it times out, fall back to the original method to construct URI originally in client/tooltip  
  - To this end, exposed `TimeoutError`; might be useful in future #1210 
  - Append `namespace` and `uri` fields  to service output object
- Accommodating changes in the client/tooltip

refs #1202 