### PR TITLE
remove hover node events for enrichment

### DIFF
--- a/src/client/features/enrichment/cy/index.js
+++ b/src/client/features/enrichment/cy/index.js
@@ -62,34 +62,6 @@ let bindEvents = cy => {
   cy.on('pan', () => hideTooltips());
   cy.on('zoom', () => hideTooltips());
   cy.on('layoutstart', () => hideTooltips());
-
-  let nodeHoverMouseOver = _.debounce(evt => {
-    let node = evt.target;
-    let elesToHighlight = cy.collection();
-
-    //Create a list of the hovered node & its neighbourhood
-    node.neighborhood().nodes().union(node).forEach(node => {
-      elesToHighlight.merge(node.ancestors());
-      elesToHighlight.merge(node.descendants());
-      elesToHighlight.merge(node);
-    });
-    elesToHighlight.merge(node.neighborhood().edges());
-
-    //Add highlighted class to node & its neighbourhood, unhighlighted to everything else
-    cy.elements().addClass('unhighlighted');
-    elesToHighlight.forEach(ele => {
-      ele.removeClass('unhighlighted');
-      ele.addClass('highlighted');
-    });
-
-  }, 750);
-
-  //call style-applying and style-removing functions on 'mouseover' and 'mouseout' for non-compartment nodes
-  cy.on('mouseover', 'node[class!="compartment"]', nodeHoverMouseOver);
-  cy.on('mouseout', 'node[class!="compartment"]', () => {
-    nodeHoverMouseOver.cancel();
-    cy.elements().removeClass('highlighted unhighlighted');
-  });
 };
 
 let searchEnrichmentNodes = _.debounce((cy, query) => {


### PR DESCRIPTION
hovering over a node no longer does anything in the enrichment app