### PR TITLE
use cose-bilkent when there is more than 1 source node for the interactions app

### DIFF
--- a/src/client/features/interactions/cy/index.js
+++ b/src/client/features/interactions/cy/index.js
@@ -14,9 +14,22 @@ const SINGLE_SRC_LAYOUT = {
   animationEasing: 'ease-in-out'
 };
 
+const MULTI_SRC_LAYOUT = {
+  name: 'cose-bilkent',
+  nodeRepulsion: 2000,
+  nodeDimensionsIncludeLabels: true,
+  animate: 'end',
+  animationEasing: 'ease-in-out',
+  animationDuration: 800,
+  fit: true,
+  padding: 75,
+  randomize: true
+};
+
 const interactionsLayoutOpts = cy => {
-  if( cy.nodes('[?queried]').size() > 1){
-    return _.assign({}, SINGLE_SRC_LAYOUT, { minNodeSpacing: 50 });
+  let numSources = cy.nodes('[?queried]').size();
+  if( numSources > 1 ){
+    return MULTI_SRC_LAYOUT;
   }
   return SINGLE_SRC_LAYOUT;
 };


### PR DESCRIPTION
When there is more than 1 source node, use a different layout (cose-bilkent) to get a better sense of the network topology

![screen shot 2018-12-17 at 2 07 36 pm](https://user-images.githubusercontent.com/2328291/50109241-32177180-0205-11e9-9d26-d530ae0ca30f.png)
