### PR TITLE
fix enrichment layout bug where the first layout bb would be 0 height width when there are only disconnected nodes

### DIFF
--- a/src/client/features/enrichment/cy/index.js
+++ b/src/client/features/enrichment/cy/index.js
@@ -29,12 +29,23 @@ let enrichmentLayout = cy => {
 
   return firstLayoutPromise.then( () => {
     let firstLayoutBB = nodesWithEdges.boundingBox();
+    let bbIsEmpty = bb => bb.h === 0 && bb.w === 0;
+
     let secondLayoutBB = {
-      x1: firstLayoutBB.x1,
-      x2: firstLayoutBB.x2,
-      y1: firstLayoutBB.y2 + 200,
-      y2: firstLayoutBB.y2 + 400
+      x1: 0,
+      x2: w,
+      y1: 0,
+      y2: h
     };
+
+    if( !bbIsEmpty( firstLayoutBB ) ){
+      secondLayoutBB = {
+        x1: firstLayoutBB.x1,
+        x2: firstLayoutBB.x2,
+        y1: firstLayoutBB.y2 + 200,
+        y2: firstLayoutBB.y2 + 400
+      };
+    }
 
     let secondLayout = nodesWithNoEdges.layout({
       name: 'grid',


### PR DESCRIPTION
- fixes the enrichment layout from failing when there are only disconnected nodes e.g. enrichment/tp53

![screen shot 2018-12-19 at 12 31 35 pm](https://user-images.githubusercontent.com/2328291/50237117-1093c280-038a-11e9-85c6-b230230b6fea.png)
