### PR TITLE
Gene display name ellipsis

### DIFF
--- a/src/styles/features/entity-landing-box.css
+++ b/src/styles/features/entity-landing-box.css
@@ -8,6 +8,7 @@
   margin: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
+  overflow: hidden;
   font-size: 0.66em;
 }
 


### PR DESCRIPTION
Missing prop for ellipsis on gene display name.

![image](https://user-images.githubusercontent.com/4706307/50929444-306b5300-142b-11e9-9117-122d22f92716.png)


refs #1242.