### PR TITLE
Error handling and user notification: Search

### DIFF
--- a/src/client/common/components/error-message.js
+++ b/src/client/common/components/error-message.js
@@ -1,0 +1,27 @@
+const React = require('react');
+const h = require('react-hyperscript');
+
+class ErrorMessage extends React.Component {
+  render(){
+    const title = h('h1.error-message-title',
+      this.props.title !== undefined ? this.props.title : 'An error occurred' );
+
+    const body = this.props.body ?
+      h('p.error-message-body', [
+        h('span', this.props.body )
+      ]) : null;
+
+    const footer = h('p.error-message-footer', this.props.footer !== undefined ? this.props.footer: [
+      h('span', 'If difficulties persist, please report this to our '),
+      h('a.plain-link', { href: 'mailto: pathway-commons-help@googlegroups.com' }, 'help forum.')
+    ]);
+
+    return  h('div.error-message', [
+      title,
+      body,
+      footer
+    ]);
+  }
+}
+
+module.exports = { ErrorMessage };

--- a/src/client/features/search/gene-results-view.js
+++ b/src/client/features/search/gene-results-view.js
@@ -59,6 +59,11 @@ class GeneResultsView extends React.Component {
 
   render(){
     let { geneResults } = this.props;
+
+    if( geneResults === null || geneResults.length === 0 ){
+      return null;
+    }
+
     let sources = geneResults.map( geneInfo => geneInfo.geneSymbol );
     let interactionsAppInfo = this.getInteractionsAppInfo( );
     let enrichmentAppInfo = this.getEnrichmentAppInfo( );

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -112,7 +112,7 @@ class Search extends React.Component {
 
     const searchListing = h(Loader, { loaded: !loading, options: { left: '50%', color: '#16A085' } }, [
       h('div', [
-        geneResults && geneResults.length > 0 ? h(GeneResultsView, { geneResults } ) : null,
+        h(GeneResultsView, { geneResults } ),
         h(PathwayResultsView, { pathwayResults, curDatasource: query.datasource, controller: this})
       ])
     ]);

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -12,6 +12,8 @@ const PcLogoLink = require('../../common/components/pc-logo-link');
 
 const { PathwayResultsView } = require('./pathway-results-view');
 const { GeneResultsView } = require('./gene-results-view');
+const { TimeoutError } = require('../../../util');
+const { ErrorMessage } = require('../../common/components/error-message');
 
 class Search extends React.Component {
 
@@ -26,9 +28,10 @@ class Search extends React.Component {
         type: 'Pathway',
         datasource: []
       }, query),
-      geneResults: [],
-      pathwayResults: [],
-      loading: false
+      geneResults: null,
+      pathwayResults: null,
+      loading: false,
+      error: null
     };
   }
 
@@ -44,10 +47,11 @@ class Search extends React.Component {
         let { genes, pathways } = res;
         this.setState({
           geneResults: genes,
-          pathwayResults: pathways,
-          loading: false
+          pathwayResults: pathways
          });
-      });
+      })
+      .catch( e => this.setState({ error: e }))
+      .finally( this.setState({ loading: false }));
     }
   }
 
@@ -106,22 +110,22 @@ class Search extends React.Component {
   render() {
     let { geneResults, pathwayResults, query, loading } = this.state;
 
-    const notFoundErrorMessage = h('div.search-error', [
-      h('h1', 'We can\'t find the the resource you are looking for'),
-      h('p', [
-        h('span', 'If difficulties persist, please report this to our '),
-        h('a.plain-link', { href: 'mailto: pathway-commons-help@googlegroups.com' }, 'help forum.')
-      ])
-    ]);
-
     const searchListing = h(Loader, { loaded: !loading, options: { left: '50%', color: '#16A085' } }, [
-      h('div.search-body', [
-        geneResults.length > 0 ? h(GeneResultsView, { geneResults } ) : null,
+      h('div', [
+        geneResults && geneResults.length > 0 ? h(GeneResultsView, { geneResults } ) : null,
         h(PathwayResultsView, { pathwayResults, curDatasource: query.datasource, controller: this})
       ])
     ]);
 
-    const searchBody =  this.props.notFoundError ? notFoundErrorMessage : searchListing;
+    let errorMessage;
+    if( this.props.notFoundError ) {
+      errorMessage = h( ErrorMessage, { title: 'We couldn\'t find the resource you are looking for', body: 'Check the location and try again.' } );
+    } else if( this.state.error instanceof TimeoutError ) {
+      errorMessage = h( ErrorMessage, { title: 'This is taking longer that we expected', body: 'Try again later.' }  );
+    } else if( this.state.error ) {
+      errorMessage = h( ErrorMessage );
+    }
+    let searchBody = errorMessage ? errorMessage : searchListing;
 
     return h('div.search', [
       h('div.search-header', [
@@ -156,7 +160,7 @@ class Search extends React.Component {
           ])
         ])
       ]),
-      h('div', [searchBody])
+      h('div.search-body', [searchBody])
     ]);
   }
 }

--- a/src/client/features/search/pathway-results-view.js
+++ b/src/client/features/search/pathway-results-view.js
@@ -5,11 +5,17 @@ const queryString = require('query-string');
 const _ = require('lodash');
 
 const Datasources = require('../../../models/datasources');
-
+const { ErrorMessage } = require('../../common/components/error-message');
 
 class PathwayResultsView extends React.Component {
   render(){
     let { pathwayResults, controller, curDatasource } = this.props;
+
+    if( pathwayResults === null ){
+      return null;
+    } else if ( !pathwayResults.length ){
+      return h( ErrorMessage, { title: 'Your search didn\'t match any pathways', footer: 'Try different keywords or gene names.'} );
+    }
 
     const searchList = pathwayResults.map(result => {
       let datasourceUri = _.get(result, 'dataSource.0', '');

--- a/src/styles/common/error-message.css
+++ b/src/styles/common/error-message.css
@@ -1,0 +1,21 @@
+.error-message {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  flex-direction: column;
+  /* padding: 10px;
+  padding-left: 215px; */
+  /* width: 60%; */
+}
+
+.error-message-body, .error-message-footer {
+  color: var(--light-base-colour-darker);
+  margin: 0;
+  font-size: 0.9em;
+}
+
+@media (--small-width-viewport) {
+  .error-message {
+    padding-left: 50px;
+  }
+}

--- a/src/styles/common/index.css
+++ b/src/styles/common/index.css
@@ -1,6 +1,7 @@
 @import "./dropdown.css";
 @import "./buttons.css";
 @import "./empty-network.css";
+@import "./error-message.css";
 @import "./pc-logo-link.css";
 @import "./sidebar.css";
 @import "./cytoscape-tooltip.css";


### PR DESCRIPTION
Refs #1210.

There are five cases handled.

- Initial load
  - Body currently displays 'Pathway Count (0)' and datasource selector. Instead:
![image](https://user-images.githubusercontent.com/4706307/51267552-031f2780-198c-11e9-9173-a96286eb1829.png)

- Unknown URL path
  - Same as before: ![image](https://user-images.githubusercontent.com/4706307/51267328-71171f00-198b-11e9-8e38-9b9e0c3e9132.png)

- No pathway hits
  - Body currently displays 'Pathway Count (0)' and datasource selector. Instead: 
![image](https://user-images.githubusercontent.com/4706307/51268125-44640700-198d-11e9-9722-13f8f0ddc2af.png)


- Fetch: Timeout
  - Currently just hangs. Instead: 
![image](https://user-images.githubusercontent.com/4706307/51267454-cf440200-198b-11e9-9d58-e04577ece47a.png)

- Fetch: Error
  - Currently just hangs. Instead:
![image](https://user-images.githubusercontent.com/4706307/51267406-a7ed3500-198b-11e9-9bfb-2a1ad3241f32.png)




