### PR TITLE
Factoid download options

### DIFF
--- a/src/client/features/pathways/index.js
+++ b/src/client/features/pathways/index.js
@@ -71,6 +71,7 @@ class Pathways extends React.Component {
 
   render() {
     let { loading, pathway, cySrv, networkEmpty, error } = this.state;
+    const { downloadOpts } = this.props;
 
     let errorMessage;
     if( networkEmpty ) {
@@ -89,7 +90,7 @@ class Pathways extends React.Component {
           h('a.plain-link', { href: pathway.datasourceUrl(), target: '_blank' }, ' ' + pathway.datasource())
         ])
       ]),
-      h(PathwaysToolbar, { cySrv, pathway })
+      h(PathwaysToolbar, { cySrv, pathway, downloadOpts })
     ]);
 
     let content = !errorMessage ? [

--- a/src/client/features/pathways/menus/file-download-menu.js
+++ b/src/client/features/pathways/menus/file-download-menu.js
@@ -60,10 +60,10 @@ class FileDownloadMenu extends React.Component {
   }
 
   render() {
-    const defaultOpts = { disabledTypes: [] }; // disable none
-    const { downloadOpts = defaultOpts } = this.props;
+    const { downloadOpts } = this.props;
+    const opts = _.assign( { disabledTypes: [] }, downloadOpts );
     let menuContents = this.state.downloadTypes.map( dt => {
-      const optionClass = downloadOpts.disabledTypes.indexOf( dt.type ) < 0 ? '': '.disabled';
+      const optionClass = opts.disabledTypes.indexOf( dt.type ) < 0 ? '': '.disabled';
       let dlOption = h('div.download-option' + optionClass, { onClick: () => this.downloadFromDisplayName( dt.displayName ) }, [
           h('div.download-option-header', [
             h('h3', dt.displayName),

--- a/src/client/features/pathways/menus/file-download-menu.js
+++ b/src/client/features/pathways/menus/file-download-menu.js
@@ -60,8 +60,10 @@ class FileDownloadMenu extends React.Component {
   }
 
   render() {
+    const { disabledTypes = [] } = this.props.downloadOpts;
     let menuContents = this.state.downloadTypes.map( dt => {
-      let dlOption = h('div.download-option', { onClick: () => this.downloadFromDisplayName( dt.displayName ) }, [
+      const optionClass = disabledTypes.indexOf( dt.type ) < 0 ? '': '.disabled';
+      let dlOption = h('div.download-option' + optionClass, { onClick: () => this.downloadFromDisplayName( dt.displayName ) }, [
           h('div.download-option-header', [
             h('h3', dt.displayName),
           ]),

--- a/src/client/features/pathways/menus/file-download-menu.js
+++ b/src/client/features/pathways/menus/file-download-menu.js
@@ -60,9 +60,10 @@ class FileDownloadMenu extends React.Component {
   }
 
   render() {
-    const { disabledTypes = [] } = this.props.downloadOpts;
+    const defaultOpts = { disabledTypes: [] }; // disable none
+    const { downloadOpts = defaultOpts } = this.props;
     let menuContents = this.state.downloadTypes.map( dt => {
-      const optionClass = disabledTypes.indexOf( dt.type ) < 0 ? '': '.disabled';
+      const optionClass = downloadOpts.disabledTypes.indexOf( dt.type ) < 0 ? '': '.disabled';
       let dlOption = h('div.download-option' + optionClass, { onClick: () => this.downloadFromDisplayName( dt.displayName ) }, [
           h('div.download-option-header', [
             h('h3', dt.displayName),

--- a/src/client/features/pathways/pathways-toolbar.js
+++ b/src/client/features/pathways/pathways-toolbar.js
@@ -27,7 +27,7 @@ class PathwaysToolbar extends React.Component {
   }
 
   render(){
-    let { cySrv, pathway } = this.props;
+    let { cySrv, pathway, downloadOpts } = this.props;
     let { searchValue } = this.state;
     let cy = cySrv.get();
 
@@ -46,7 +46,7 @@ class PathwaysToolbar extends React.Component {
       h(Popover, {
         tippy: {
           position: 'bottom',
-          html: h(FileDownloadMenu, { key: 'downloadMenu', cySrv, fileName: pathway.name(), uri: pathway.uri() })
+          html: h(FileDownloadMenu, { key: 'downloadMenu', cySrv, fileName: pathway.name(), uri: pathway.uri(), downloadOpts })
         }
       }, [
         h(IconButton, {

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -68,9 +68,12 @@ module.exports = () => {
             type: 'factoids',
             id
           };
+          const downloadOpts = { // see /common/pc-download-types.js
+            disabledTypes: [ 'gmt', 'sif', 'txt', 'biopax', 'jsonld', 'sbgn' ]
+          };
 
           logPageView( pathname + id );
-          return h(Features.Pathways, _.assign( {}, props, { apiOpts } ));
+          return h(Features.Pathways, _.assign( {}, props, { apiOpts, downloadOpts } ));
         }
       },
       {

--- a/src/styles/common/menus.css
+++ b/src/styles/common/menus.css
@@ -122,3 +122,17 @@
   cursor: pointer;
   font-size: 0.8em;
 }
+
+.download-option.disabled, .download-option.disabled:hover {
+  color: var(--light-base-colour-dark);
+  cursor: default;
+  background-color: #fff;
+  pointer-events: none;
+
+  & * {
+    cursor: default;
+    background-color: #fff;
+  }
+}
+
+


### PR DESCRIPTION
Added a general option to explicitly disable certain 'pc-download-types' in the toolbar file-download-menu button. 

Factoid looks like this:

![image](https://user-images.githubusercontent.com/4706307/51621627-f4dc8880-1f02-11e9-99f1-7857bb9a2938.png)


Refs #1196 