### PR TITLE
Using the BioPax Suggester implementation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ let defaults = {
   PORT: 3000,
   METADATA_CRON_SCHEDULE: '0 0 * * Monday', // update file from gprofiler etc. (Monday at midnight)
   PC_URL: 'http://www.pathwaycommons.org/',
+  XREF_SERVICE_URL: 'http://biopax.baderlab.org/',
   GPROFILER_URL: "https://biit.cs.ut.ee/gprofiler/",
   IDENTIFIERS_URL: 'http://identifiers.org',
   NCBI_EUTILS_BASE_URL: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils',

--- a/src/server/external-services/pathway-commons.js
+++ b/src/server/external-services/pathway-commons.js
@@ -19,6 +19,8 @@ const fetchOptions = {
   }
 };
 
+const toJSON = res => res.json();
+
 //Pathway Commons HTTP GET request; options.cmd = 'pc2/get', 'pc2/search', 'pc2/traverse', 'pc2/graph', etc.
 let query = opts => {
   let queryOpts = _.assign( { user: 'app-ui', cmd: 'pc2/get' }, opts);
@@ -68,8 +70,10 @@ const sifGraph = opts => {
   });
 };
 
-const handleEntityUriResponse = text => {
-  const uri = new url.URL( text ); // Throws TypeError
+const handleXrefServiceResponse = res => {
+  const { values } = res;
+  const xrefInfo = _.head( values );
+  const uri = new url.URL( xrefInfo.uri ); // Throws TypeError
   const pathParts = _.compact( uri.pathname.split('/') );
   if( _.isEmpty( pathParts ) || pathParts.length !== 2 ) throw new Error( 'Unrecognized URI' );
   const namespace = _.head( pathParts );
@@ -79,24 +83,26 @@ const handleEntityUriResponse = text => {
   };
 };
 
-const constructQueryPath = ( name, localId ) => {
-  // Edge case - localId has periods e.g. 'enzyme nomenclature/6.1.1.5' gotta add a trailing slash
-  const suffix = /\./.test( localId ) ? '/' : '';
-  return name + '/' + localId + suffix;
-};
+const formatXrefQuery = ( name, localId ) => _.concat( [], { db: name, id: localId } );
 
 /* fetchEntityUriBase
- * Light wrapper around the pc2 service to get the uri given a collection name and local ID for entity
- * http://www.pathwaycommons.org/pc2/swagger-ui.html#!/metadata45controller/identifierOrgUriUsingGET
- * NB: pc2 service returns 200 and empty body if collection name and/or local ID are unrecognized.
- *   If the local ID is empty, throws a 404
+ * Light wrapper around the BioPAX service to fetch URI given a collection name and local ID for entity
+ * http://biopax.baderlab.org/docs/index.html#_introduction
  * @return { object } the URL origin and namespace
  */
 const fetchEntityUriBase = ( name, localId ) => {
-  const url = config.PC_URL + 'pc2/miriam/uri/' + constructQueryPath( name, localId ) ;
-  return fetch( url , { method: 'GET', headers: { 'Accept': 'text/plain' } })
-    .then( res => res.text() )
-    .then( handleEntityUriResponse )
+  const url = config.XREF_SERVICE_URL + 'xref/';
+  const fetchOpts = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body:  JSON.stringify( formatXrefQuery( name, localId ) )
+  };
+  return fetch( url , fetchOpts )
+    .then( toJSON )
+    .then( handleXrefServiceResponse )
     .catch( error => {
       if( error instanceof TypeError ) throw new InvalidParamError('Unrecognized parameters');
       throw error;
@@ -106,10 +112,13 @@ const fetchEntityUriBase = ( name, localId ) => {
 const getEntityUriParts = cachePromise(fetchEntityUriBase, xrefCache, name => name);
 
 /*
- * xref2Uri: Obtain the URI for an xref
+ * xref2Uri
+ * Obtain the URI for an xref
  * @param {string} name -  MIRIAM 'name', 'synonym' ?OR MI CV database citation (MI:0444) 'label'
  * @param {string} localId - Entity local entity identifier, should be valid
  * @return {Object} return the origin and 'namespace' in path
+ *
+ * This could be updated to accept array of { name, localId } fields now....
  */
 const xref2Uri =  ( name, localId ) => {
   return getEntityUriParts( name, localId )

--- a/src/server/routes/pathway-commons-router.js
+++ b/src/server/routes/pathway-commons-router.js
@@ -10,8 +10,9 @@ router.get('/search', function (req, res) {
 });
 
 //for debugging
-router.get('/xref2Uri/:name/:localId', function (req, res, next) {
-  pc.xref2Uri( req.params.name, req.params.localId )
+router.post('/xref2Uri/', function (req, res, next) {
+  const { name, localId } = req.body.query[0];
+  pc.xref2Uri( name, localId )
     .then( r => res.json( r ))
     .catch( next );
 });

--- a/src/server/routes/pathway-commons-router.js
+++ b/src/server/routes/pathway-commons-router.js
@@ -11,7 +11,7 @@ router.get('/search', function (req, res) {
 
 //for debugging
 router.post('/xref2Uri/', function (req, res, next) {
-  const { name, localId } = req.body.query[0];
+  const { name, localId } = req.body.query;
   pc.xref2Uri( name, localId )
     .then( r => res.json( r ))
     .catch( next );

--- a/test/server/enrichment/visualization/visualization-test.js
+++ b/test/server/enrichment/visualization/visualization-test.js
@@ -16,8 +16,21 @@ const ENRICHMENT_NETWORK_JSON = require('./enrichment-network-json.json');
 describe('Test generateGraphInfo - Enrichment Vizualization Service', function () {
   it('parameters: all valid', async () => {
     const table = await getPathwayInfoTable();
+    const mockResponse =  {
+      values: [
+        {
+          "db": "name",
+          "id": "id",
+          "uri": "http://identifiers.org/name/id",
+          "dbOk": true,
+          "idOk": true,
+          "preferredDb": "name",
+          "namespace": "namespace"
+        }
+      ]
+    };
 
-    global.fetch = mockFetch( { text: () => 'http://identifiers.org/name/id' } );
+    global.fetch = mockFetch( { json: () => mockResponse } );
     const res = await generateEnrichmentNetworkJson(table, [
       {
         "id": "GO:0006354",

--- a/test/server/pathways/pathways-network-generation.js
+++ b/test/server/pathways/pathways-network-generation.js
@@ -4,43 +4,28 @@ const path = require('path');
 const { fillInBiopaxMetadata } = require('../../../src/server/routes/pathways/generate-pathway-json/biopax-metadata');
 const sampleCyjsonData = require('./sample-cyjson-data');
 const sampleMetadataOut = require('./sample-cyjson-out.json');
-
-const fakeMiriamService = new Map([
-  ['chebi', 'chebi'],
-  ['molecular interactions ontology', 'psimi'],
-  ['mi', 'psimi'],
-  ['chebi', 'chebi'],
-  ['reactome', 'reactome'],
-  ['pubmed', 'pubmed'],
-  ['uniprot knowledgebase', 'uniprot'],
-  ['hgnc symbol', 'hgnc.symbol'],
-  ['gene ontology', 'go'],
-  ['ensembl', 'ensembl'],
-  ['protein modification ontology', 'mod']
-]);
-
-function mockFetch(){
-  const urlParts = arguments[0].split('/');
-  const name = urlParts[6];
-  const localId = urlParts[7];
-  return new Promise( resolve => {
-    resolve({
-      ok: true,
-      text: () => fakeMiriamService.has(name) ? `http://identifiers.org/${fakeMiriamService.get(name)}/${localId}`: ''
-    });
-  });
-}
-
-
+const { mockFetch } = require('../../util');
 
 describe('Pathways network generation', function(){
 
   it('Should return correct metadata from getBiopaxMetadata', async () => {
-    global.fetch = mockFetch;
+    const mockResponse =  {
+      values: [
+        {
+          "db": "name",
+          "id": "id",
+          "uri": "http://identifiers.org/name/id",
+          "dbOk": true,
+          "idOk": true,
+          "preferredDb": "name",
+          "namespace": "namespace"
+        }
+      ]
+    };
+
+    global.fetch = mockFetch( { json: () => mockResponse } );
     let sampleBiopaxData = fs.readFileSync(path.resolve(__dirname, './sample-biopax-data.txt'), 'utf-8');
-
     let result = await fillInBiopaxMetadata( sampleCyjsonData, sampleBiopaxData );
-
     expect( result ).to.deep.equal( sampleMetadataOut );
   });
 });

--- a/test/server/pathways/sample-cyjson-out.json
+++ b/test/server/pathways/sample-cyjson-out.json
@@ -1,1420 +1,1234 @@
 {
-  "nodes":[
+   "nodes": [
      {
-        "data":{
-           "id":"http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
-           "class":"process",
-           "label":"",
-           "parent":"cytosol",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
+         "class": "process",
+         "label": "",
+         "parent": "cytosol",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 7.5,
+           "y": 7.5,
+           "w": 15,
+           "h": 15
+         },
+         "metadata": {
+           "comments": [
+             "Edited: Orlic-Milacic, Marija, 2015-10-14",
+             "PCBP4 binds the 3'-UTR of the CDKN1A (p21) mRNA and reduces its stability (Scoumanne et al. 2011).",
+             "Reviewed: Zaccara, Sara, 2016-02-04",
+             "Authored: Orlic-Milacic, Marija, 2015-10-14",
+             "Reviewed: Inga, Alberto, 2016-02-04"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":7.5,
-              "y":7.5,
-              "w":15,
-              "h":15
-           },
-           "metadata":{
-              "comments":[
-                 "Edited: Orlic-Milacic, Marija, 2015-10-14",
-                 "PCBP4 binds the 3'-UTR of the CDKN1A (p21) mRNA and reduces its stability (Scoumanne et al. 2011).",
-                 "Reviewed: Zaccara, Sara, 2016-02-04",
-                 "Authored: Orlic-Milacic, Marija, 2015-10-14",
-                 "Reviewed: Inga, Alberto, 2016-02-04"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"BiochemicalReaction",
-              "standardName":"",
-              "displayName":"PCBP4 binds the CDKN1A mRNA",
-              "xrefLinks":{
-                 "pubmed":[
-                    "http://identifiers.org/pubmed/20817677"
-                 ],
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803403"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "BiochemicalReaction",
+           "standardName": "",
+           "displayName": "PCBP4 binds the CDKN1A mRNA",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/20817677",
+               "http://identifiers.org/name/R-HSA-6803403"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
-           "class":"process",
-           "label":"",
-           "parent":"cytosol",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
+         "class": "process",
+         "label": "",
+         "parent": "cytosol",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 7.5,
+           "y": 7.5,
+           "w": 15,
+           "h": 15
+         },
+         "metadata": {
+           "comments": [
+             "Reviewed: Zaccara, Sara, 2016-02-04",
+             "Reviewed: Inga, Alberto, 2016-02-04",
+             "Edited: Orlic-Milacic, Marija, 2015-10-14",
+             "Authored: Orlic-Milacic, Marija, 2015-10-14",
+             "PCBP4 binding to the 3'-UTR of the CDKN1A (p21) mRNA reduces half-life of the CDKN1A mRNA and the amount of CDKN1A protein. Upon DNA damage, TP53-mediated induction of CDKN1A is rapid, while the induction of PCBP4 is more gradual. It is hypothesized that, under prolonged stress, PCBP4-mediated down-regulation of CDKN1A may switch from G1 cell cycle arrest to G2 arrest, which may precede apoptosis (Scoumanne et al. 2011)."
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":7.5,
-              "y":7.5,
-              "w":15,
-              "h":15
-           },
-           "metadata":{
-              "comments":[
-                 "Reviewed: Zaccara, Sara, 2016-02-04",
-                 "Reviewed: Inga, Alberto, 2016-02-04",
-                 "Edited: Orlic-Milacic, Marija, 2015-10-14",
-                 "Authored: Orlic-Milacic, Marija, 2015-10-14",
-                 "PCBP4 binding to the 3'-UTR of the CDKN1A (p21) mRNA reduces half-life of the CDKN1A mRNA and the amount of CDKN1A protein. Upon DNA damage, TP53-mediated induction of CDKN1A is rapid, while the induction of PCBP4 is more gradual. It is hypothesized that, under prolonged stress, PCBP4-mediated down-regulation of CDKN1A may switch from G1 cell cycle arrest to G2 arrest, which may precede apoptosis (Scoumanne et al. 2011)."
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"BiochemicalReaction",
-              "standardName":"",
-              "displayName":"PCBP4 modulates CDKN1A translation",
-              "xrefLinks":{
-                 "pubmed":[
-                    "http://identifiers.org/pubmed/20817677"
-                 ],
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803411"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "BiochemicalReaction",
+           "standardName": "",
+           "displayName": "PCBP4 modulates CDKN1A translation",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/20817677",
+               "http://identifiers.org/name/R-HSA-6803411"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
-           "class":"complex",
-           "label":"PCBP4:CDKN1A mRNA",
-           "parent":"cytosol",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
+         "class": "complex",
+         "label": "PCBP4:CDKN1A mRNA",
+         "parent": "cytosol",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 25,
+           "y": 15,
+           "w": 54,
+           "h": 34
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Complex4632",
+             "Reactome DB_ID: 6803405"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":25,
-              "y":15,
-              "w":54,
-              "h":34
-           },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Complex4632",
-                 "Reactome DB_ID: 6803405"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Complex",
-              "standardName":"",
-              "displayName":"PCBP4:CDKN1A mRNA",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803405"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Complex",
+           "standardName": "",
+           "displayName": "PCBP4:CDKN1A mRNA",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803405"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f_5178567a47ecc386c9cd4c86331da218",
-           "class":"nucleic acid feature",
-           "label":"CDKN1A",
-           "parent":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
-           "clonemarker":false,
-           "stateVariables":[
-
-           ],
-           "unitsOfInformation":[
-              {
-                 "id":null,
-                 "class":"unit of information",
-                 "label":{
-                    "text":"mt:RNA"
-                 }
-              }
-           ],
-           "bbox":{
-              "x":25,
-              "y":15,
-              "w":50,
-              "h":30
-           },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Rna95",
-                 "Reactome DB_ID: 6803386"
-              ],
-              "synonyms":[
-                 "CDKN1A mRNA",
-                 "ENSEMBL:ENST00000244741 CDKN1A"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Rna",
-              "standardName":"",
-              "displayName":"p21 mRNA",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803386"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/CDKN1A"
-                 ],
-                 "ensembl":[
-                    "http://identifiers.org/ensembl/ENST00000244741"
-                 ]
-              }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f_5178567a47ecc386c9cd4c86331da218",
+         "class": "nucleic acid feature",
+         "label": "CDKN1A",
+         "parent": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [
+           {
+             "id": null,
+             "class": "unit of information",
+             "label": {
+               "text": "mt:RNA"
+             }
            }
-        }
+         ],
+         "bbox": {
+           "x": 25,
+           "y": 15,
+           "w": 50,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Rna95",
+             "Reactome DB_ID: 6803386"
+           ],
+           "synonyms": [
+             "CDKN1A mRNA",
+             "ENSEMBL:ENST00000244741 CDKN1A"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Rna",
+           "standardName": "",
+           "displayName": "p21 mRNA",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803386",
+               "http://identifiers.org/name/CDKN1A",
+               "http://identifiers.org/name/P38936",
+               "http://identifiers.org/name/ENST00000244741"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494_5178567a47ecc386c9cd4c86331da218",
-           "class":"macromolecule",
-           "label":"PCBP4",
-           "parent":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
-           "clonemarker":false,
-           "stateVariables":[
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"",
-                    "value":"x[1 - 403]"
-                 }
-              }
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":24,
-              "y":15,
-              "w":48,
-              "h":30
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 6803382",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10458"
-              ],
-              "synonyms":[
-                 "Alpha-CP4",
-                 "Poly(rC)-binding protein 4",
-                 "MCG10",
-                 "PCBP4"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Poly(rC)-binding protein 4",
-              "displayName":"PCBP4",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803382"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/PCBP4"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/P57723"
-                 ]
-              }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494_5178567a47ecc386c9cd4c86331da218",
+         "class": "macromolecule",
+         "label": "PCBP4",
+         "parent": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
+         "clonemarker": false,
+         "stateVariables": [
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "",
+               "value": "x[1 - 403]"
+             }
            }
-        }
+         ],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 24,
+           "y": 15,
+           "w": 48,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 6803382",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10458"
+           ],
+           "synonyms": [
+             "Alpha-CP4",
+             "Poly(rC)-binding protein 4",
+             "MCG10",
+             "PCBP4"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Poly(rC)-binding protein 4",
+           "displayName": "PCBP4",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803382",
+               "http://identifiers.org/name/PCBP4",
+               "http://identifiers.org/name/P57723"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494",
-           "class":"macromolecule",
-           "label":"PCBP4",
-           "parent":"cytosol",
-           "clonemarker":false,
-           "stateVariables":[
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"",
-                    "value":"x[1 - 403]"
-                 }
-              }
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":24,
-              "y":15,
-              "w":48,
-              "h":30
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 6803382",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10458"
-              ],
-              "synonyms":[
-                 "Alpha-CP4",
-                 "Poly(rC)-binding protein 4",
-                 "MCG10",
-                 "PCBP4"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Poly(rC)-binding protein 4",
-              "displayName":"PCBP4",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803382"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/PCBP4"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/P57723"
-                 ]
-              }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494",
+         "class": "macromolecule",
+         "label": "PCBP4",
+         "parent": "cytosol",
+         "clonemarker": false,
+         "stateVariables": [
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "",
+               "value": "x[1 - 403]"
+             }
            }
-        }
+         ],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 24,
+           "y": 15,
+           "w": 48,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 6803382",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10458"
+           ],
+           "synonyms": [
+             "Alpha-CP4",
+             "Poly(rC)-binding protein 4",
+             "MCG10",
+             "PCBP4"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Poly(rC)-binding protein 4",
+           "displayName": "PCBP4",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803382",
+               "http://identifiers.org/name/PCBP4",
+               "http://identifiers.org/name/P57723"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
-           "class":"nucleic acid feature",
-           "label":"CDKN1A",
-           "parent":"cytosol",
-           "clonemarker":false,
-           "stateVariables":[
-
-           ],
-           "unitsOfInformation":[
-              {
-                 "id":null,
-                 "class":"unit of information",
-                 "label":{
-                    "text":"mt:RNA"
-                 }
-              }
-           ],
-           "bbox":{
-              "x":25,
-              "y":15,
-              "w":50,
-              "h":30
-           },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Rna95",
-                 "Reactome DB_ID: 6803386"
-              ],
-              "synonyms":[
-                 "CDKN1A mRNA",
-                 "ENSEMBL:ENST00000244741 CDKN1A"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Rna",
-              "standardName":"",
-              "displayName":"p21 mRNA",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803386"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/CDKN1A"
-                 ],
-                 "ensembl":[
-                    "http://identifiers.org/ensembl/ENST00000244741"
-                 ]
-              }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
+         "class": "nucleic acid feature",
+         "label": "CDKN1A",
+         "parent": "cytosol",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [
+           {
+             "id": null,
+             "class": "unit of information",
+             "label": {
+               "text": "mt:RNA"
+             }
            }
-        }
+         ],
+         "bbox": {
+           "x": 25,
+           "y": 15,
+           "w": 50,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Rna95",
+             "Reactome DB_ID: 6803386"
+           ],
+           "synonyms": [
+             "CDKN1A mRNA",
+             "ENSEMBL:ENST00000244741 CDKN1A"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Rna",
+           "standardName": "",
+           "displayName": "p21 mRNA",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803386",
+               "http://identifiers.org/name/CDKN1A",
+               "http://identifiers.org/name/P38936",
+               "http://identifiers.org/name/ENST00000244741"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
-           "class":"process",
-           "label":"",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
+         "class": "process",
+         "label": "",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 7.5,
+           "y": 7.5,
+           "w": 15,
+           "h": 15
+         },
+         "metadata": {
+           "comments": [
+             "Reviewed: Inga, Alberto, 2016-02-04",
+             "Reviewed: Zaccara, Sara, 2016-02-04",
+             "ZNF385A (HZF) forms a complex with TP53 (p53), interacting with the DNA binding domain of TP53. The complex of TP53 and ZNF385A associates with p53 response elements of cell cycle arrest genes, such as CDKN1A (p21) and stimulates their transcription. Under prolonged stress, ZNF385A undergoes ubiquitination and proteasome-mediated degradation, which coincides with expression of TP53-regulated pro-apoptotic genes (Das et al. 2007).",
+             "Authored: Orlic-Milacic, Marija, 2015-10-14",
+             "Edited: Orlic-Milacic, Marija, 2015-10-14"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":7.5,
-              "y":7.5,
-              "w":15,
-              "h":15
-           },
-           "metadata":{
-              "comments":[
-                 "Reviewed: Inga, Alberto, 2016-02-04",
-                 "Reviewed: Zaccara, Sara, 2016-02-04",
-                 "ZNF385A (HZF) forms a complex with TP53 (p53), interacting with the DNA binding domain of TP53. The complex of TP53 and ZNF385A associates with p53 response elements of cell cycle arrest genes, such as CDKN1A (p21) and stimulates their transcription. Under prolonged stress, ZNF385A undergoes ubiquitination and proteasome-mediated degradation, which coincides with expression of TP53-regulated pro-apoptotic genes (Das et al. 2007).",
-                 "Authored: Orlic-Milacic, Marija, 2015-10-14",
-                 "Edited: Orlic-Milacic, Marija, 2015-10-14"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"BiochemicalReaction",
-              "standardName":"",
-              "displayName":"TP53 binds ZNF385A",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803719"
-                 ],
-                 "pubmed":[
-                    "http://identifiers.org/pubmed/17719541"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "BiochemicalReaction",
+           "standardName": "",
+           "displayName": "TP53 binds ZNF385A",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803719",
+               "http://identifiers.org/name/17719541"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
-           "class":"process",
-           "label":"",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
+         "class": "process",
+         "label": "",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 7.5,
+           "y": 7.5,
+           "w": 15,
+           "h": 15
+         },
+         "metadata": {
+           "comments": [
+             "Authored: Orlic-Milacic, Marija, 2015-10-14",
+             "Edited: Orlic-Milacic, Marija, 2015-10-14",
+             "Reviewed: Inga, Alberto, 2016-02-04",
+             "Reviewed: Coqueret, O, 2006-10-06 08:59:06",
+             "Binding of TP53 (p53) to its response elements in the promoter of the CDKN1A (p21) gene stimulates CDKN1A transcription (El-Deiry et al. 1993). Binding of ZNF385A (HZF) to the DNA binding domain of TP53 facilitates CDKN1A induction and the consequent cell cycle arrest (Das et al. 2007).",
+             "Reviewed: Zaccara, Sara, 2016-02-04",
+             "Authored: Matthews, L, 2006-09-29 13:54:26"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":7.5,
-              "y":7.5,
-              "w":15,
-              "h":15
-           },
-           "metadata":{
-              "comments":[
-                 "Authored: Orlic-Milacic, Marija, 2015-10-14",
-                 "Edited: Orlic-Milacic, Marija, 2015-10-14",
-                 "Reviewed: Inga, Alberto, 2016-02-04",
-                 "Reviewed: Coqueret, O, 2006-10-06 08:59:06",
-                 "Binding of TP53 (p53) to its response elements in the promoter of the CDKN1A (p21) gene stimulates CDKN1A transcription (El-Deiry et al. 1993). Binding of ZNF385A (HZF) to the DNA binding domain of TP53 facilitates CDKN1A induction and the consequent cell cycle arrest (Das et al. 2007).",
-                 "Reviewed: Zaccara, Sara, 2016-02-04",
-                 "Authored: Matthews, L, 2006-09-29 13:54:26"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"BiochemicalReaction",
-              "standardName":"",
-              "displayName":"TP53 stimulates CDKN1A (p21) transcription",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803388"
-                 ],
-                 "pubmed":[
-                    "http://identifiers.org/pubmed/17719541",
-                    "http://identifiers.org/pubmed/8242752"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "BiochemicalReaction",
+           "standardName": "",
+           "displayName": "TP53 stimulates CDKN1A (p21) transcription",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803388",
+               "http://identifiers.org/name/17719541",
+               "http://identifiers.org/name/8242752"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
-           "class":"process",
-           "label":"",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
+         "class": "process",
+         "label": "",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 7.5,
+           "y": 7.5,
+           "w": 15,
+           "h": 15
+         },
+         "metadata": {
+           "comments": [
+             "Reviewed: Inga, Alberto, 2016-02-04",
+             "Edited: Orlic-Milacic, Marija, 2015-10-14",
+             "TP53 (p53) binds at least two p53 response elements in the promoter of the CDKN1A (p21, WAF1) gene (El-Deiry et al. 1993, Espinosa et al. 2003). Formation of the complex of TP53 and ZNF385A (HZF) facilitates binding of TP53 to the CDKN1A promoter (Das et al. 2007).",
+             "Authored: Orlic-Milacic, M, 2013-07-15",
+             "Reviewed: Samarajiwa, Shamith, 2013-09-03",
+             "Reviewed: Zaccara, Sara, 2016-02-04",
+             "Authored: Orlic-Milacic, Marija, 2015-10-14"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":7.5,
-              "y":7.5,
-              "w":15,
-              "h":15
-           },
-           "metadata":{
-              "comments":[
-                 "Reviewed: Inga, Alberto, 2016-02-04",
-                 "Edited: Orlic-Milacic, Marija, 2015-10-14",
-                 "TP53 (p53) binds at least two p53 response elements in the promoter of the CDKN1A (p21, WAF1) gene (El-Deiry et al. 1993, Espinosa et al. 2003). Formation of the complex of TP53 and ZNF385A (HZF) facilitates binding of TP53 to the CDKN1A promoter (Das et al. 2007).",
-                 "Authored: Orlic-Milacic, M, 2013-07-15",
-                 "Reviewed: Samarajiwa, Shamith, 2013-09-03",
-                 "Reviewed: Zaccara, Sara, 2016-02-04",
-                 "Authored: Orlic-Milacic, Marija, 2015-10-14"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"BiochemicalReaction",
-              "standardName":"",
-              "displayName":"TP53 in complex with ZNF385A binds the CDKN1A promoter",
-              "xrefLinks":{
-                 "pubmed":[
-                    "http://identifiers.org/pubmed/14580351",
-                    "http://identifiers.org/pubmed/8242752",
-                    "http://identifiers.org/pubmed/17719541"
-                 ],
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803801"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "BiochemicalReaction",
+           "standardName": "",
+           "displayName": "TP53 in complex with ZNF385A binds the CDKN1A promoter",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/14580351",
+               "http://identifiers.org/name/8242752",
+               "http://identifiers.org/name/R-HSA-6803801",
+               "http://identifiers.org/name/17719541"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2",
-           "class":"macromolecule",
-           "label":"ZNF385A",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2",
+         "class": "macromolecule",
+         "label": "ZNF385A",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 24,
+           "y": 12.5,
+           "w": 48,
+           "h": 25
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 6803421",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10457"
            ],
-           "unitsOfInformation":[
-
+           "synonyms": [
+             "Zinc finger protein 385A",
+             "ZNF385A",
+             "ZNF385",
+             "Retinal zinc finger protein",
+             "Hematopoietic zinc finger protein",
+             "RZF",
+             "HZF"
            ],
-           "bbox":{
-              "x":24,
-              "y":12.5,
-              "w":48,
-              "h":25
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 6803421",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10457"
-              ],
-              "synonyms":[
-                 "Zinc finger protein 385A",
-                 "ZNF385A",
-                 "ZNF385",
-                 "Retinal zinc finger protein",
-                 "Hematopoietic zinc finger protein",
-                 "RZF",
-                 "HZF"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Zinc finger protein 385A",
-              "displayName":"HZF",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803421"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/ZNF385A"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/Q96PM9"
-                 ]
-              }
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Zinc finger protein 385A",
+           "displayName": "HZF",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803421",
+               "http://identifiers.org/name/ZNF385A",
+               "http://identifiers.org/name/Q96PM9"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef",
-           "class":"macromolecule",
-           "label":"CDKN1A",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"",
-                    "value":"x[2 - 164]"
-                 }
-              }
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":24,
-              "y":15,
-              "w":48,
-              "h":30
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 182585",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein1393"
-              ],
-              "synonyms":[
-                 "CDKN1A",
-                 "CAP20",
-                 "WAF1",
-                 "CDKN1",
-                 "PIC1",
-                 "p21",
-                 "MDA-6",
-                 "MDA6",
-                 "Melanoma differentiation-associated protein 6",
-                 "SDI1",
-                 "CDK-interacting protein 1",
-                 "CIP1"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Cyclin-dependent kinase inhibitor 1",
-              "displayName":"p21",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-182585"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/CDKN1A"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/P38936"
-                 ]
-              }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef",
+         "class": "macromolecule",
+         "label": "CDKN1A",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "",
+               "value": "x[2 - 164]"
+             }
            }
-        }
+         ],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 24,
+           "y": 15,
+           "w": 48,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 182585",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein1393"
+           ],
+           "synonyms": [
+             "CDKN1A",
+             "CAP20",
+             "WAF1",
+             "CDKN1",
+             "PIC1",
+             "p21",
+             "MDA-6",
+             "MDA6",
+             "Melanoma differentiation-associated protein 6",
+             "SDI1",
+             "CDK-interacting protein 1",
+             "CIP1"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Cyclin-dependent kinase inhibitor 1",
+           "displayName": "p21",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-182585",
+               "http://identifiers.org/name/CDKN1A",
+               "http://identifiers.org/name/P38936"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "class":"complex",
-           "label":"p-S15,S20-TP53 Tetramer:ZNF385A:CDKN1A Gene",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "class": "complex",
+         "label": "p-S15,S20-TP53 Tetramer:ZNF385A:CDKN1A Gene",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 42.5,
+           "y": 15,
+           "w": 89,
+           "h": 34
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Complex4631",
+             "Reactome DB_ID: 6803802"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":42.5,
-              "y":15,
-              "w":89,
-              "h":34
-           },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Complex4631",
-                 "Reactome DB_ID: 6803802"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Complex",
-              "standardName":"",
-              "displayName":"p-S15,S20-TP53 Tetramer:ZNF385A:CDKN1A Gene",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803802"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Complex",
+           "standardName": "",
+           "displayName": "p-S15,S20-TP53 Tetramer:ZNF385A:CDKN1A Gene",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803802"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_1bda2d80d7f26e79f1ec46b69ea62814_e084db4218995c6713265fec7de6398c",
-           "class":"macromolecule",
-           "label":"TP53",
-           "parent":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "clonemarker":false,
-           "stateVariables":[
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"20",
-                    "value":"opser-51"
-                 }
-              },
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"15",
-                    "value":"opser-51"
-                 }
-              },
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"",
-                    "value":"x[1 - 393]"
-                 }
-              }
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":42.5,
-              "y":15,
-              "w":85,
-              "h":30
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_1bda2d80d7f26e79f1ec46b69ea62814_e084db4218995c6713265fec7de6398c",
+         "class": "macromolecule",
+         "label": "TP53",
+         "parent": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "clonemarker": false,
+         "stateVariables": [
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "20",
+               "value": "opser-51"
+             }
            },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10449",
-                 "Reactome DB_ID: 69683"
-              ],
-              "synonyms":[
-                 "Tumor suppressor p53",
-                 "TP53",
-                 "Antigen NY-CO-13",
-                 "Phosphoprotein p53",
-                 "P53"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Cellular tumor antigen p53",
-              "displayName":"p-S15,S20-TP53",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-69683"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/TP53"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/P04637"
-                 ]
-              }
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "15",
+               "value": "opser-51"
+             }
+           },
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "",
+               "value": "x[1 - 393]"
+             }
            }
-        }
+         ],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 42.5,
+           "y": 15,
+           "w": 85,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10449",
+             "Reactome DB_ID: 69683"
+           ],
+           "synonyms": [
+             "Tumor suppressor p53",
+             "TP53",
+             "Antigen NY-CO-13",
+             "Phosphoprotein p53",
+             "P53"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Cellular tumor antigen p53",
+           "displayName": "p-S15,S20-TP53",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-69683",
+               "http://identifiers.org/name/TP53",
+               "http://identifiers.org/name/P04637"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56_e084db4218995c6713265fec7de6398c",
-           "class":"nucleic acid feature",
-           "label":"CDKN1A",
-           "parent":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "clonemarker":false,
-           "stateVariables":[
-
-           ],
-           "unitsOfInformation":[
-              {
-                 "id":null,
-                 "class":"unit of information",
-                 "label":{
-                    "text":"mt:DNA"
-                 }
-              }
-           ],
-           "bbox":{
-              "x":25,
-              "y":15,
-              "w":50,
-              "h":30
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 3786256",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Dna50"
-              ],
-              "synonyms":[
-                 "WAF1 gene",
-                 "CIP1 gene",
-                 "CDKN1A gene",
-                 "PIC1",
-                 "CAP20",
-                 "CDKN1A",
-                 "WAF1",
-                 "MDA6",
-                 "CDKN1",
-                 "SDI1",
-                 "ENSEMBL:ENSG00000124762 CDKN1A"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Dna",
-              "standardName":"",
-              "displayName":"p21 gene",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-3786256"
-                 ],
-                 "ensembl":[
-                    "http://identifiers.org/ensembl/ENSG00000124762"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/CDKN1A"
-                 ]
-              }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56_e084db4218995c6713265fec7de6398c",
+         "class": "nucleic acid feature",
+         "label": "CDKN1A",
+         "parent": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [
+           {
+             "id": null,
+             "class": "unit of information",
+             "label": {
+               "text": "mt:DNA"
+             }
            }
-        }
+         ],
+         "bbox": {
+           "x": 25,
+           "y": 15,
+           "w": 50,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 3786256",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Dna50"
+           ],
+           "synonyms": [
+             "WAF1 gene",
+             "CIP1 gene",
+             "CDKN1A gene",
+             "PIC1",
+             "CAP20",
+             "CDKN1A",
+             "WAF1",
+             "MDA6",
+             "CDKN1",
+             "SDI1",
+             "ENSEMBL:ENSG00000124762 CDKN1A"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Dna",
+           "standardName": "",
+           "displayName": "p21 gene",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-3786256",
+               "http://identifiers.org/name/P38936",
+               "http://identifiers.org/name/ENSG00000124762",
+               "http://identifiers.org/name/CDKN1A"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2_e084db4218995c6713265fec7de6398c",
-           "class":"macromolecule",
-           "label":"ZNF385A",
-           "parent":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2_e084db4218995c6713265fec7de6398c",
+         "class": "macromolecule",
+         "label": "ZNF385A",
+         "parent": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 24,
+           "y": 12.5,
+           "w": 48,
+           "h": 25
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 6803421",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10457"
            ],
-           "unitsOfInformation":[
-
+           "synonyms": [
+             "Zinc finger protein 385A",
+             "ZNF385A",
+             "ZNF385",
+             "Retinal zinc finger protein",
+             "Hematopoietic zinc finger protein",
+             "RZF",
+             "HZF"
            ],
-           "bbox":{
-              "x":24,
-              "y":12.5,
-              "w":48,
-              "h":25
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 6803421",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10457"
-              ],
-              "synonyms":[
-                 "Zinc finger protein 385A",
-                 "ZNF385A",
-                 "ZNF385",
-                 "Retinal zinc finger protein",
-                 "Hematopoietic zinc finger protein",
-                 "RZF",
-                 "HZF"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Zinc finger protein 385A",
-              "displayName":"HZF",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803421"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/ZNF385A"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/Q96PM9"
-                 ]
-              }
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Zinc finger protein 385A",
+           "displayName": "HZF",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803421",
+               "http://identifiers.org/name/ZNF385A",
+               "http://identifiers.org/name/Q96PM9"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
-           "class":"nucleic acid feature",
-           "label":"CDKN1A",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
-           ],
-           "unitsOfInformation":[
-              {
-                 "id":null,
-                 "class":"unit of information",
-                 "label":{
-                    "text":"mt:DNA"
-                 }
-              }
-           ],
-           "bbox":{
-              "x":25,
-              "y":15,
-              "w":50,
-              "h":30
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 3786256",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Dna50"
-              ],
-              "synonyms":[
-                 "WAF1 gene",
-                 "CIP1 gene",
-                 "CDKN1A gene",
-                 "PIC1",
-                 "CAP20",
-                 "CDKN1A",
-                 "WAF1",
-                 "MDA6",
-                 "CDKN1",
-                 "SDI1",
-                 "ENSEMBL:ENSG00000124762 CDKN1A"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Dna",
-              "standardName":"",
-              "displayName":"p21 gene",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-3786256"
-                 ],
-                 "ensembl":[
-                    "http://identifiers.org/ensembl/ENSG00000124762"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/CDKN1A"
-                 ]
-              }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
+         "class": "nucleic acid feature",
+         "label": "CDKN1A",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [
+           {
+             "id": null,
+             "class": "unit of information",
+             "label": {
+               "text": "mt:DNA"
+             }
            }
-        }
+         ],
+         "bbox": {
+           "x": 25,
+           "y": 15,
+           "w": 50,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 3786256",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Dna50"
+           ],
+           "synonyms": [
+             "WAF1 gene",
+             "CIP1 gene",
+             "CDKN1A gene",
+             "PIC1",
+             "CAP20",
+             "CDKN1A",
+             "WAF1",
+             "MDA6",
+             "CDKN1",
+             "SDI1",
+             "ENSEMBL:ENSG00000124762 CDKN1A"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Dna",
+           "standardName": "",
+           "displayName": "p21 gene",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-3786256",
+               "http://identifiers.org/name/P38936",
+               "http://identifiers.org/name/ENSG00000124762",
+               "http://identifiers.org/name/CDKN1A"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
-           "class":"complex",
-           "label":"p-S15,S20-TP53 Tetramer",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
+         "class": "complex",
+         "label": "p-S15,S20-TP53 Tetramer",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 42.5,
+           "y": 15,
+           "w": 89,
+           "h": 34
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Complex4625",
+             "Reactome DB_ID: 3222171"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":42.5,
-              "y":15,
-              "w":89,
-              "h":34
-           },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Complex4625",
-                 "Reactome DB_ID: 3222171"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Complex",
-              "standardName":"",
-              "displayName":"p-S15,S20-TP53 Tetramer",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-3222171"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Complex",
+           "standardName": "",
+           "displayName": "p-S15,S20-TP53 Tetramer",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-3222171"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_1bda2d80d7f26e79f1ec46b69ea62814_118feaa670629f9e2393b181ce87eec2",
-           "class":"macromolecule",
-           "label":"TP53",
-           "parent":"http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
-           "clonemarker":false,
-           "stateVariables":[
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"20",
-                    "value":"opser-51"
-                 }
-              },
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"15",
-                    "value":"opser-51"
-                 }
-              },
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"",
-                    "value":"x[1 - 393]"
-                 }
-              }
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":42.5,
-              "y":15,
-              "w":85,
-              "h":30
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_1bda2d80d7f26e79f1ec46b69ea62814_118feaa670629f9e2393b181ce87eec2",
+         "class": "macromolecule",
+         "label": "TP53",
+         "parent": "http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
+         "clonemarker": false,
+         "stateVariables": [
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "20",
+               "value": "opser-51"
+             }
            },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10449",
-                 "Reactome DB_ID: 69683"
-              ],
-              "synonyms":[
-                 "Tumor suppressor p53",
-                 "TP53",
-                 "Antigen NY-CO-13",
-                 "Phosphoprotein p53",
-                 "P53"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Cellular tumor antigen p53",
-              "displayName":"p-S15,S20-TP53",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-69683"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/TP53"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/P04637"
-                 ]
-              }
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "15",
+               "value": "opser-51"
+             }
+           },
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "",
+               "value": "x[1 - 393]"
+             }
            }
-        }
+         ],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 42.5,
+           "y": 15,
+           "w": 85,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10449",
+             "Reactome DB_ID: 69683"
+           ],
+           "synonyms": [
+             "Tumor suppressor p53",
+             "TP53",
+             "Antigen NY-CO-13",
+             "Phosphoprotein p53",
+             "P53"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Cellular tumor antigen p53",
+           "displayName": "p-S15,S20-TP53",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-69683",
+               "http://identifiers.org/name/TP53",
+               "http://identifiers.org/name/P04637"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
-           "class":"complex",
-           "label":"p-S15,S20-TP53 Tetramer:ZNF385A",
-           "parent":"nucleoplasm",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
+         "class": "complex",
+         "label": "p-S15,S20-TP53 Tetramer:ZNF385A",
+         "parent": "nucleoplasm",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 42.5,
+           "y": 15,
+           "w": 89,
+           "h": 34
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Complex4630",
+             "Reactome DB_ID: 6803718"
            ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":42.5,
-              "y":15,
-              "w":89,
-              "h":34
-           },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Complex4630",
-                 "Reactome DB_ID: 6803718"
-              ],
-              "synonyms":[
-
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Complex",
-              "standardName":"",
-              "displayName":"p-S15,S20-TP53 Tetramer:ZNF385A",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803718"
-                 ]
-              }
+           "synonyms": [],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Complex",
+           "standardName": "",
+           "displayName": "p-S15,S20-TP53 Tetramer:ZNF385A",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803718"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_1bda2d80d7f26e79f1ec46b69ea62814_8f3ce9a594ac249a622a48b0f53f0b29",
-           "class":"macromolecule",
-           "label":"TP53",
-           "parent":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
-           "clonemarker":false,
-           "stateVariables":[
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"20",
-                    "value":"opser-51"
-                 }
-              },
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"15",
-                    "value":"opser-51"
-                 }
-              },
-              {
-                 "id":null,
-                 "class":"state variable",
-                 "state":{
-                    "variable":"",
-                    "value":"x[1 - 393]"
-                 }
-              }
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":42.5,
-              "y":15,
-              "w":85,
-              "h":30
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_1bda2d80d7f26e79f1ec46b69ea62814_8f3ce9a594ac249a622a48b0f53f0b29",
+         "class": "macromolecule",
+         "label": "TP53",
+         "parent": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
+         "clonemarker": false,
+         "stateVariables": [
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "20",
+               "value": "opser-51"
+             }
            },
-           "metadata":{
-              "comments":[
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10449",
-                 "Reactome DB_ID: 69683"
-              ],
-              "synonyms":[
-                 "Tumor suppressor p53",
-                 "TP53",
-                 "Antigen NY-CO-13",
-                 "Phosphoprotein p53",
-                 "P53"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Cellular tumor antigen p53",
-              "displayName":"p-S15,S20-TP53",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-69683"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/TP53"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/P04637"
-                 ]
-              }
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "15",
+               "value": "opser-51"
+             }
+           },
+           {
+             "id": null,
+             "class": "state variable",
+             "state": {
+               "variable": "",
+               "value": "x[1 - 393]"
+             }
            }
-        }
+         ],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 42.5,
+           "y": 15,
+           "w": 85,
+           "h": 30
+         },
+         "metadata": {
+           "comments": [
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10449",
+             "Reactome DB_ID: 69683"
+           ],
+           "synonyms": [
+             "Tumor suppressor p53",
+             "TP53",
+             "Antigen NY-CO-13",
+             "Phosphoprotein p53",
+             "P53"
+           ],
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Cellular tumor antigen p53",
+           "displayName": "p-S15,S20-TP53",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-69683",
+               "http://identifiers.org/name/TP53",
+               "http://identifiers.org/name/P04637"
+             ]
+           }
+         }
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2_8f3ce9a594ac249a622a48b0f53f0b29",
-           "class":"macromolecule",
-           "label":"ZNF385A",
-           "parent":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
-           "clonemarker":false,
-           "stateVariables":[
-
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2_8f3ce9a594ac249a622a48b0f53f0b29",
+         "class": "macromolecule",
+         "label": "ZNF385A",
+         "parent": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 24,
+           "y": 12.5,
+           "w": 48,
+           "h": 25
+         },
+         "metadata": {
+           "comments": [
+             "Reactome DB_ID: 6803421",
+             "REPLACED http://www.reactome.org/biopax/64/48887#Protein10457"
            ],
-           "unitsOfInformation":[
-
+           "synonyms": [
+             "Zinc finger protein 385A",
+             "ZNF385A",
+             "ZNF385",
+             "Retinal zinc finger protein",
+             "Hematopoietic zinc finger protein",
+             "RZF",
+             "HZF"
            ],
-           "bbox":{
-              "x":24,
-              "y":12.5,
-              "w":48,
-              "h":25
-           },
-           "metadata":{
-              "comments":[
-                 "Reactome DB_ID: 6803421",
-                 "REPLACED http://www.reactome.org/biopax/64/48887#Protein10457"
-              ],
-              "synonyms":[
-                 "Zinc finger protein 385A",
-                 "ZNF385A",
-                 "ZNF385",
-                 "Retinal zinc finger protein",
-                 "Hematopoietic zinc finger protein",
-                 "RZF",
-                 "HZF"
-              ],
-              "datasource":"http://pathwaycommons.org/pc2/reactome",
-              "type":"Protein",
-              "standardName":"Zinc finger protein 385A",
-              "displayName":"HZF",
-              "xrefLinks":{
-                 "reactome":[
-                    "http://identifiers.org/reactome/R-HSA-6803421"
-                 ],
-                 "hgnc.symbol":[
-                    "http://identifiers.org/hgnc.symbol/ZNF385A"
-                 ],
-                 "uniprot":[
-                    "http://identifiers.org/uniprot/Q96PM9"
-                 ]
-              }
+           "datasource": "http://pathwaycommons.org/pc2/reactome",
+           "type": "Protein",
+           "standardName": "Zinc finger protein 385A",
+           "displayName": "HZF",
+           "xrefLinks": {
+             "name": [
+               "http://identifiers.org/name/R-HSA-6803421",
+               "http://identifiers.org/name/ZNF385A",
+               "http://identifiers.org/name/Q96PM9"
+             ]
            }
-        }
+         }
+       }
      },
      {
-        "data":{
-           "id":"cytosol",
-           "class":"compartment",
-           "label":"cytosol",
-           "parent":"",
-           "clonemarker":false,
-           "stateVariables":[
-
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":25,
-              "y":15,
-              "w":58,
-              "h":38
-           },
-           "metadata":{
-
-           }
-        }
+       "data": {
+         "id": "cytosol",
+         "class": "compartment",
+         "label": "cytosol",
+         "parent": "",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 25,
+           "y": 15,
+           "w": 58,
+           "h": 38
+         },
+         "metadata": {}
+       }
      },
      {
-        "data":{
-           "id":"nucleoplasm",
-           "class":"compartment",
-           "label":"nucleoplasm",
-           "parent":"",
-           "clonemarker":false,
-           "stateVariables":[
-
-           ],
-           "unitsOfInformation":[
-
-           ],
-           "bbox":{
-              "x":42.5,
-              "y":15,
-              "w":93,
-              "h":38
-           },
-           "metadata":{
-
-           }
-        }
+       "data": {
+         "id": "nucleoplasm",
+         "class": "compartment",
+         "label": "nucleoplasm",
+         "parent": "",
+         "clonemarker": false,
+         "stateVariables": [],
+         "unitsOfInformation": [],
+         "bbox": {
+           "x": 42.5,
+           "y": 15,
+           "w": 93,
+           "h": 38
+         },
+         "metadata": {}
+       }
      }
-  ],
-  "edges":[
+   ],
+   "edges": [
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f--TO--INP_http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
-           "target":"http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f--TO--INP_http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
+         "target": "http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"OUT_http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "class":"production",
-           "cardinality":0,
-           "source":"http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
-           "target":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
-           "portTarget":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334"
-        }
+       "data": {
+         "id": "OUT_http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "class": "production",
+         "cardinality": 0,
+         "source": "http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
+         "target": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "bendPointPositions": [],
+         "portSource": "http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
+         "portTarget": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f--TO--INP_http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
-           "target":"http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f--TO--INP_http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
+         "target": "http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"OUT_http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
-           "class":"production",
-           "cardinality":0,
-           "source":"http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
-           "target":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
-           "portTarget":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba"
-        }
+       "data": {
+         "id": "OUT_http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
+         "class": "production",
+         "cardinality": 0,
+         "source": "http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
+         "target": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
+         "bendPointPositions": [],
+         "portSource": "http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
+         "portTarget": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049--TO--http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
-           "class":"inhibition",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
-           "target":"http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049--TO--http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
+         "class": "inhibition",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
+         "target": "http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56--TO--INP_http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
-           "target":"http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56--TO--INP_http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
+         "target": "http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56--TO--INP_http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
-           "target":"http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56--TO--INP_http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
+         "target": "http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Dna_91b0bb49fefe3673ba23d46ddacefc56",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494--TO--INP_http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494",
-           "target":"http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494--TO--INP_http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494",
+         "target": "http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Protein_c1f5c065e6bc72127ca56ee0bf005494",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"OUT_http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
-           "class":"production",
-           "cardinality":0,
-           "source":"http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
-           "target":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
-           "portTarget":"http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f"
-        }
+       "data": {
+         "id": "OUT_http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
+         "class": "production",
+         "cardinality": 0,
+         "source": "http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
+         "target": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f",
+         "bendPointPositions": [],
+         "portSource": "http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
+         "portTarget": "http://pathwaycommons.org/pc2/Rna_b0c799710a192ab1ed6794a6332e3b0f"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334--TO--http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
-           "class":"stimulation",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "target":"http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334--TO--http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
+         "class": "stimulation",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "target": "http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Complex_293d627d8f9f22b9e72ebcd86909d334",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803388_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"OUT_http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef",
-           "class":"production",
-           "cardinality":0,
-           "source":"http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
-           "target":"http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
-           "portTarget":"http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef"
-        }
+       "data": {
+         "id": "OUT_http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef",
+         "class": "production",
+         "cardinality": 0,
+         "source": "http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
+         "target": "http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef",
+         "bendPointPositions": [],
+         "portSource": "http://identifiers.org/reactome/R-HSA-6803411_LEFTTORIGHT",
+         "portTarget": "http://pathwaycommons.org/pc2/Protein_9d656b3e41b0c69ff45a305f058b3cef"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14--TO--INP_http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
-           "target":"http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14--TO--INP_http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
+         "target": "http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Complex_e4c55477314b3d4bfd4b8f47ceff3e14",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"OUT_http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
-           "class":"production",
-           "cardinality":0,
-           "source":"http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
-           "target":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
-           "portTarget":"http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049"
-        }
+       "data": {
+         "id": "OUT_http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT--TO--http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
+         "class": "production",
+         "cardinality": 0,
+         "source": "http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
+         "target": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049",
+         "bendPointPositions": [],
+         "portSource": "http://identifiers.org/reactome/R-HSA-6803403_LEFTTORIGHT",
+         "portTarget": "http://pathwaycommons.org/pc2/Complex_e5eadb29e1ffa1af7e4743cca5684049"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba--TO--INP_http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
-           "target":"http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba--TO--INP_http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
+         "target": "http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Complex_3b9bde21e8f130870b91f73ac31dcaba",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803801_LEFTTORIGHT"
+       }
      },
      {
-        "data":{
-           "id":"http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2--TO--INP_http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
-           "class":"consumption",
-           "cardinality":0,
-           "source":"http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2",
-           "target":"http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
-           "bendPointPositions":[
-
-           ],
-           "portSource":"http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2",
-           "portTarget":"http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT"
-        }
+       "data": {
+         "id": "http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2--TO--INP_http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
+         "class": "consumption",
+         "cardinality": 0,
+         "source": "http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2",
+         "target": "http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT",
+         "bendPointPositions": [],
+         "portSource": "http://pathwaycommons.org/pc2/Protein_74816ffc8af8e1d43b16b1226a5c0db2",
+         "portTarget": "http://identifiers.org/reactome/R-HSA-6803719_LEFTTORIGHT"
+       }
      }
-  ]
-}
+   ]
+ }


### PR DESCRIPTION
Swaps out the web service endpoint underlying `xref2Uri` that maps an xref (db, id) to URI. In particular, making *minimal* changes to replace  `http://www.pathwaycommons.org//pc2/miriam/uri/{db}/{id}` for `http://biopax.baderlab.org/xref/`.

Refs #1221. 