### PR TITLE
Swapping out Datasources file by returning info in search results.

### DIFF
--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -29,7 +29,8 @@ class Search extends React.Component {
         datasource: []
       }, query),
       geneResults: null,
-      pathwayResults: null,
+      searchHits: null,
+      dataSources: [],
       loading: false,
       error: null
     };
@@ -44,10 +45,11 @@ class Search extends React.Component {
         loading: true,
       });
       ServerAPI.search( query ).then( res => {
-        let { genes, pathways } = res;
+        let { genes, searchHits, dataSources } = res;
         this.setState({
           geneResults: genes,
-          pathwayResults: pathways,
+          searchHits,
+          dataSources,
           loading: false
          });
       })
@@ -108,12 +110,12 @@ class Search extends React.Component {
   }
 
   render() {
-    let { geneResults, pathwayResults, query, loading } = this.state;
+    let { geneResults, searchHits, query, loading, dataSources } = this.state;
 
     const searchListing = h(Loader, { loaded: !loading, options: { left: '50%', color: '#16A085' } }, [
       h('div', [
         h(GeneResultsView, { geneResults } ),
-        h(PathwayResultsView, { pathwayResults, curDatasource: query.datasource, controller: this})
+        h(PathwayResultsView, { searchHits, query, controller: this, dataSources})
       ])
     ]);
 

--- a/src/client/features/search/pathway-results-view.js
+++ b/src/client/features/search/pathway-results-view.js
@@ -4,12 +4,15 @@ const Link = require('react-router-dom').Link;
 const queryString = require('query-string');
 const _ = require('lodash');
 
-const Datasources = require('../../../models/datasources');
 const { ErrorMessage } = require('../../common/components/error-message');
 
 class PathwayResultsView extends React.Component {
   render(){
-    let { pathwayResults, controller, curDatasource } = this.props;
+    let { searchHits: pathwayResults, controller, query , dataSources } = this.props;
+    const curDatasource = query.datasource;
+    const sources = dataSources.filter( source => query.type === 'Pathway' ?
+      !source.notPathwayData && source.numPathways :
+      !source.notPathwayData && source.numInteractions );
     const noPathwaysMsg = h( ErrorMessage, { title: 'Your search didn\'t match any pathways', footer: 'Try different keywords or gene names.'} );
 
     if( pathwayResults === null ){
@@ -17,8 +20,7 @@ class PathwayResultsView extends React.Component {
     }
 
     const searchList = pathwayResults.map(result => {
-      let datasourceUri = _.get(result, 'dataSource.0', '');
-      let dsInfo = Datasources.findByUri(datasourceUri);
+      let dsInfo = _.get( result, 'sourceInfo', '' );
       let iconUrl = dsInfo.iconUrl || '';
       let name = dsInfo.name || '';
 
@@ -41,7 +43,7 @@ class PathwayResultsView extends React.Component {
         onChange: e => controller.setAndSubmitSearchQuery({ datasource: e.target.value })
       }, [
         h('option', { value: [] }, 'Any datasource')].concat(
-          Datasources.pathwayDatasources().map( ds => h('option', { value: [ds.id ] }, ds.name ))
+          sources.map( ds => h('option', { value: [ds.id ] }, ds.name ))
           )),
     ]);
 

--- a/src/server/routes/search/search.js
+++ b/src/server/routes/search/search.js
@@ -105,9 +105,9 @@ const searchPathways = query => {
  * @param { String } query Raw input to search by
  */
 const search = async ( query ) => {
-  return Promise.all([ searchGenes( query.q ), searchPathways( query ) ])
-    .then( ([ genes, pathways ]) => {
-      return { genes, pathways };
+  return Promise.all([ searchGenes( query.q ), searchPathways( query ), pc.getDataSources() ])
+    .then( ([ genes, searchHits, dataSources ]) => {
+      return { genes, searchHits, dataSources };
     } );
 };
 


### PR DESCRIPTION
- Use the PC supported web service to get datasource information in place of hard-coded mapping file
- Integrate required datasource info for  searchHits directly into search response from server
  
Refs #1296  