### PR TITLE
Interactions tooltip error fallback

### DIFF
--- a/src/client/features/interactions/interactions-edge-tooltip.js
+++ b/src/client/features/interactions/interactions-edge-tooltip.js
@@ -22,7 +22,8 @@ class InteractionsEdgeTooltip extends React.Component {
     this.setState({ publicationsLoaded: false }, () => {
       ServerAPI.getPubmedPublications(pubmedIds).then( publications => {
         this.setState({publications, publicationsLoaded: true});
-      });
+      })
+      .catch( () => this.setState({ publicationsLoaded: true }) ); // swallow;
     });
   }
 


### PR DESCRIPTION
Interactions tooltip: Simply bypass errors encountered when attempting to fetch publications and show minimal data. 
Refs #1312 