### PR TITLE
Interactions tooltip: Remove state calls in render

### DIFF
--- a/src/client/features/interactions/interactions-edge-tooltip.js
+++ b/src/client/features/interactions/interactions-edge-tooltip.js
@@ -9,11 +9,13 @@ class InteractionsEdgeTooltip extends React.Component {
   constructor(props){
     super(props);
 
+    const edges = props.edge.parallelEdges();
+
     this.state = {
       publications: [],
       publicationsLoaded: false,
-      parallelEdges: props.edge.parallelEdges(),
-      selectedEdge: props.edge.parallelEdges().length === 1 ? props.edge.parallelEdges()[0]: null
+      parallelEdges: edges,
+      selectedEdge: edges.length === 1 ? edges[0]: null
     };
   }
 

--- a/src/client/features/interactions/interactions-edge-tooltip.js
+++ b/src/client/features/interactions/interactions-edge-tooltip.js
@@ -12,8 +12,15 @@ class InteractionsEdgeTooltip extends React.Component {
     this.state = {
       publications: [],
       publicationsLoaded: false,
-      parallelEdges: props.edge.parallelEdges()
+      parallelEdges: props.edge.parallelEdges(),
+      selectedEdge: props.edge.parallelEdges().length === 1 ? props.edge.parallelEdges()[0]: null
     };
+  }
+
+  componentDidMount() {
+    if( this.state.selectedEdge ){
+      this.getPublications( this.state.selectedEdge );
+    }
   }
 
   getPublications(edge){
@@ -37,8 +44,9 @@ class InteractionsEdgeTooltip extends React.Component {
     this.setState({ selectedEdge: null });
   }
 
-  renderEdge(edge, publications = []){
-    let { parallelEdges, publicationsLoaded } = this.state;
+  renderEdge(){
+    let { selectedEdge: edge, parallelEdges, publicationsLoaded, publications } = this.state;
+
     let title = edge.data('id');
     let datasources = edge.data('datasources');
     let pcIds = edge.data('pcIds');
@@ -103,7 +111,8 @@ class InteractionsEdgeTooltip extends React.Component {
     ]);
   }
 
-  renderEdgeChoice(edges){
+  renderEdgeChoice(){
+    const { parallelEdges: edges } = this.state;
     let interactionTypeValues = Object.keys(INTERACTION_TYPES).map(k => INTERACTION_TYPES[k]);
 
     return h('div.cy-tooltip', [
@@ -126,17 +135,12 @@ class InteractionsEdgeTooltip extends React.Component {
   }
 
   render(){
-    let { publications, selectedEdge, parallelEdges } = this.state;
+    let { selectedEdge } = this.state;
 
     if( selectedEdge ){
-      return this.renderEdge(selectedEdge, publications);
+      return this.renderEdge();
     } else {
-      if( parallelEdges.length === 1 ){
-        this.selectEdge(parallelEdges[0]);
-        return this.renderEdge(parallelEdges[0], []);
-      } else {
-        return this.renderEdgeChoice(parallelEdges);
-      }
+      return this.renderEdgeChoice();
     }
   }
 }


### PR DESCRIPTION
Cleanup: Set initial state during construction/mounting rather than during render().
Refs #1316.