### PR TITLE
Show interactions card only when data exists

### DIFF
--- a/src/client/features/search/gene-results-view.js
+++ b/src/client/features/search/gene-results-view.js
@@ -76,12 +76,12 @@ class GeneResultsView extends React.Component {
 
       let img = h( `div.app-image.${imageClass}` );
       let appImage = h( Link,{ to: { pathname: linkPath, search: queryString.stringify({ source: sources.join(',') }) }, target: '_blank' }, [ img ]);
-      let appTitle = h( 'div', [ h( 'h4.app-title', title ) ] );
+      let appHeader = h( 'div.app-header', [ h( 'h4.app-title', title ) ] );
       let appDescription = h( 'div.app-description', description );
 
       if( !enabled ){
         appImage = img;
-        appTitle = h( 'div.app-header', [
+        appHeader = h( 'div.app-header', [
           h( 'h4.app-title', title ),
           h( 'span.app-hint', hint )
         ]);
@@ -94,7 +94,7 @@ class GeneResultsView extends React.Component {
         }, [
         appImage,
         h('div.app-linkout-content', [
-          appTitle,
+          appHeader,
           appDescription
         ])
       ]);

--- a/src/client/features/search/index.js
+++ b/src/client/features/search/index.js
@@ -52,6 +52,7 @@ class Search extends React.Component {
           dataSources,
           loading: false
          });
+        return null; // Bluebird warning
       })
       .catch( e => this.setState({ error: e, loading: false }));
     }

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -66,12 +66,10 @@ const ServerAPI = {
     );
   },
 
-  getInteractionGraph( sources, peek = false ) {
-    const fetchOpts = _.assign( {}, defaultFetchOpts, { method: peek ? 'HEAD': 'GET' } );
-    const handleResponse = res => peek ? res: res.json();
+  getInteractionGraph(sources) {
     return (
-      fetch( `/api/interactions?${qs.stringify( sources )}`, fetchOpts )
-       .then( handleResponse )
+      fetch(`/api/interactions?${qs.stringify(sources)}`, defaultFetchOpts)
+       .then( res => res.json())
     );
   },
 

--- a/src/client/services/server-api/index.js
+++ b/src/client/services/server-api/index.js
@@ -66,10 +66,12 @@ const ServerAPI = {
     );
   },
 
-  getInteractionGraph(sources) {
+  getInteractionGraph( sources, peek = false ) {
+    const fetchOpts = _.assign( {}, defaultFetchOpts, { method: peek ? 'HEAD': 'GET' } );
+    const handleResponse = res => peek ? res: res.json();
     return (
-      fetch(`/api/interactions?${qs.stringify(sources)}`, defaultFetchOpts)
-       .then( res => res.json())
+      fetch( `/api/interactions?${qs.stringify( sources )}`, fetchOpts )
+       .then( handleResponse )
     );
   },
 

--- a/src/styles/features/search.css
+++ b/src/styles/features/search.css
@@ -148,6 +148,14 @@
   position: relative;
   overflow: hidden;
   padding-bottom: 1.75em;
+
+  &.app-linkout-disabled {
+    opacity: 0.5;
+
+    & a {
+      cursor: default;
+    }
+  }
 }
 
 .app-linkout-content {
@@ -166,6 +174,15 @@
 .app-title {
   margin: 0;
   padding-bottom: 0.5em;
+}
+
+.app-header {
+  margin-bottom: 0.5em;
+}
+
+.app-hint {
+  text-decoration: underline;
+  margin-bottom: 1em;
 }
 
 .app-linkouts {


### PR DESCRIPTION
The app cards already have a `show` flag for display. This PR provides a means to 'peek' at the interactions data in order to set the interaction card `show`.

Refs #1251.

Sample data: TMCC2 FUT10 GPR65 STPG2  (TP53)