### PR TITLE
Interactions tooltip has typo in 'name' for xref.

### DIFF
--- a/src/client/features/interactions/interactions-node-tooltip.js
+++ b/src/client/features/interactions/interactions-node-tooltip.js
@@ -28,7 +28,7 @@ class InteractionsNodeTooltip extends React.Component {
           name = 'NCBI Gene';
           break;
         case NS_GENECARDS:
-          name = 'NCBI Gene';
+          name = 'GeneCards';
           break;
         default:
           name = null;


### PR DESCRIPTION
Refs #1357 