### PR TITLE
Make validation target database optional  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ dist: trusty
 language: node_js
 node_js:
   - "8"
-  - "stable"
+  - "10"
 script: npm run test:travis

--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -27,7 +27,7 @@ const createGConvertOpts = opts => {
     target: NS_HGNC,
     numeric_ns: 'ENTREZGENE_ACC'
   };
-  const target = GPROFILER_NS_MAP.get(  _.get( opts, ['targetDb'], defaults.target ) );
+  const target = GPROFILER_NS_MAP.get(  _.get( opts, ['namespace'], defaults.target ) );
   const query = _.get( opts, ['query'] );
   let gConvertOpts = _.assign( {}, defaults, { query, target } );
   
@@ -36,7 +36,7 @@ const createGConvertOpts = opts => {
   }
 
   if( target == null ){
-    throw new InvalidParamError( `Error creating gconvert request - expected a valid "targetDb", got ${target}`);
+    throw new InvalidParamError( `Error creating gconvert request - expected a valid "namespace", got ${target}`);
   }
   
   return gConvertOpts;

--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -27,21 +27,18 @@ const createGConvertOpts = opts => {
     target: NS_HGNC,
     numeric_ns: 'ENTREZGENE_ACC'
   };
-
-  let gConvertOpts = _.assign({}, defaults, opts);
-  let { query, target } = gConvertOpts;
-
+  const target = GPROFILER_NS_MAP.get(  _.get( opts, ['targetDb'], defaults.target ) );
+  const query = _.get( opts, ['query'] );
+  let gConvertOpts = _.assign( {}, defaults, { query, target } );
+  
   if( !Array.isArray( query ) ){
     throw new InvalidParamError( `Error creating gconvert request - expected an array of strings for "query", got ${query}`);
   }
-  let gconvertTarget = GPROFILER_NS_MAP.get( target );
 
-  if( gconvertTarget == null ){
+  if( target == null ){
     throw new InvalidParamError( `Error creating gconvert request - expected a valid "targetDb", got ${target}`);
   }
-
-  gConvertOpts.target = gconvertTarget;
-
+  
   return gConvertOpts;
 };
 

--- a/src/server/routes/enrichment/index.js
+++ b/src/server/routes/enrichment/index.js
@@ -86,11 +86,8 @@ enrichmentRouter.get('/docs', ( req, res ) => {
 */
 // expose a rest endpoint for validation service
 enrichmentRouter.post('/validation', (req, res, next) => {
-  const query = req.body.query;
-  const tmpOptions = {
-    target: req.body.targetDb
-  };
-  validatorGconvert(query, tmpOptions)
+  const { query, targetDb } = req.body;
+  validatorGconvert( query, { targetDb } )
     .then( result => res.json( result ))
     .catch( next );
 });

--- a/src/server/routes/enrichment/index.js
+++ b/src/server/routes/enrichment/index.js
@@ -80,14 +80,14 @@ enrichmentRouter.get('/docs', ( req, res ) => {
  *         schema:
  *           "$ref": "#/definitions/success/validationSuccess"
  *       '400':
- *         description: Invalid input (organism, targetDb, or JSON format)
+ *         description: Invalid input (organism, namespace, or JSON format)
  *         schema:
  *           "$ref": "#/definitions/error/validationError"
 */
 // expose a rest endpoint for validation service
 enrichmentRouter.post('/validation', (req, res, next) => {
-  const { query, targetDb } = req.body;
-  validatorGconvert( query, { targetDb } )
+  const { query, namespace } = req.body;
+  validatorGconvert( query, { namespace } )
     .then( result => res.json( result ))
     .catch( next );
 });
@@ -182,7 +182,7 @@ enrichmentRouter.post('/visualization', (req, res, next) => {
  *     validationError:
  *       type: object
  *       properties:
- *         invalidTargetDb:
+ *         invalidNamespace:
  *           type: string
  *           example: ENSGGGGG
  *         invalidOrganism:
@@ -207,7 +207,7 @@ enrichmentRouter.post('/visualization', (req, res, next) => {
  *           example: ["TP53", "111", "AFF4", "111", "11998"]
  *           items:
  *             type: string
- *         targetDb:
+ *         namespace:
  *           type: string
  *           description: "MIRIAM collection namespace to map to (see http://identifiers.org/) \n Default: hgnc"
  *           example: "ensembl"

--- a/src/server/routes/search/search.js
+++ b/src/server/routes/search/search.js
@@ -80,8 +80,8 @@ const searchGenes = query => {
 
   return Promise.all([
     uniqueTokens,
-    validatorGconvert( uniqueTokens, { target: NS_NCBI_GENE } ),
-    validatorGconvert( uniqueTokens, { target: NS_UNIPROT } )
+    validatorGconvert( uniqueTokens, { namespace: NS_NCBI_GENE } ),
+    validatorGconvert( uniqueTokens, { namespace: NS_UNIPROT } )
   ])
   .then( ([ uniqueTokens, ncbiValidation, uniprotValidation ]) => {
     const { alias: ncbiAlias } = ncbiValidation;

--- a/test/server/enrichment/validation/validation-test.js
+++ b/test/server/enrichment/validation/validation-test.js
@@ -24,7 +24,7 @@ const defaultOptions = {
 };
 
 const userOptions = {
-  'targetDb': NS_HGNC_SYMBOL
+  'namespace': NS_HGNC_SYMBOL
 };
 
 const validResult1 = {
@@ -52,35 +52,35 @@ describe ('Enrichment service: validation', function () {
   describe ('Test creation of gconvert options', function () {
     const baseParams = {
       'query': query1,
-      'targetDb': NS_HGNC
+      'namespace': NS_HGNC
     };
 
     it ('should map name for HGNC Symbol', function () {
-      const params = _.assign( {}, baseParams, { 'targetDb': NS_HGNC_SYMBOL } );
+      const params = _.assign( {}, baseParams, { 'namespace': NS_HGNC_SYMBOL } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_HGNC_SYMBOL) );
     });
 
     it ('should map name for HGNC', function () {
-      const params = _.assign( {}, baseParams, { 'targetDb': NS_HGNC } );
+      const params = _.assign( {}, baseParams, { 'namespace': NS_HGNC } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_HGNC) );
     });
 
     it ('should map name for UniProt', function () {
-      const params = _.assign( {}, baseParams, { 'targetDb': NS_UNIPROT } );
+      const params = _.assign( {}, baseParams, { 'namespace': NS_UNIPROT } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_UNIPROT) );
     });
 
     it ('should map name for NCBI Gene', function () {
-      const params = _.assign( {}, baseParams, { 'targetDb': NS_NCBI_GENE } );
+      const params = _.assign( {}, baseParams, { 'namespace': NS_NCBI_GENE } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_NCBI_GENE) );
     });
 
     it ('should map name for Ensembl Gene', function () {
-      const params = _.assign( {}, baseParams, { 'targetDb': NS_ENSEMBL } );
+      const params = _.assign( {}, baseParams, { 'namespace': NS_ENSEMBL } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_ENSEMBL) );
     });
@@ -103,7 +103,7 @@ describe ('Enrichment service: validation', function () {
     });
 
     it ('should throw error with invalid user options', function () {
-      expect( () => createGConvertOpts( _.assign( {}, { query: query1 }, { targetDb: 'bloat' } ) ) ).to.throw ( InvalidParamError );
+      expect( () => createGConvertOpts( _.assign( {}, { query: query1 }, { namespace: 'bloat' } ) ) ).to.throw ( InvalidParamError );
       expect( () => createGConvertOpts( _.assign( {}, { query: '' } ) ) ).to.throw ( InvalidParamError );
     });
   });

--- a/test/server/enrichment/validation/validation-test.js
+++ b/test/server/enrichment/validation/validation-test.js
@@ -19,12 +19,12 @@ const query1 = [
 
 const defaultOptions = {
   'organism': 'hsapiens',
-  'target': NS_HGNC,
+  'target': GPROFILER_NS_MAP.get( NS_HGNC ),
   'numeric_ns': 'ENTREZGENE_ACC'
 };
 
 const userOptions = {
-  'target': NS_HGNC_SYMBOL
+  'targetDb': NS_HGNC_SYMBOL
 };
 
 const validResult1 = {
@@ -52,51 +52,49 @@ describe ('Enrichment service: validation', function () {
   describe ('Test creation of gconvert options', function () {
     const baseParams = {
       'query': query1,
-      'target': NS_HGNC,
-      'organism': 'hsapiens'
+      'targetDb': NS_HGNC
     };
 
     it ('should map name for HGNC Symbol', function () {
-      const params = _.assign( {}, baseParams, { 'target': NS_HGNC_SYMBOL } );
+      const params = _.assign( {}, baseParams, { 'targetDb': NS_HGNC_SYMBOL } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_HGNC_SYMBOL) );
     });
 
     it ('should map name for HGNC', function () {
-      const params = _.assign( {}, baseParams, { 'target': NS_HGNC } );
+      const params = _.assign( {}, baseParams, { 'targetDb': NS_HGNC } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_HGNC) );
     });
 
     it ('should map name for UniProt', function () {
-      const params = _.assign( {}, baseParams, { 'target': NS_UNIPROT } );
+      const params = _.assign( {}, baseParams, { 'targetDb': NS_UNIPROT } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_UNIPROT) );
     });
 
     it ('should map name for NCBI Gene', function () {
-      const params = _.assign( {}, baseParams, { 'target': NS_NCBI_GENE } );
+      const params = _.assign( {}, baseParams, { 'targetDb': NS_NCBI_GENE } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_NCBI_GENE) );
     });
 
     it ('should map name for Ensembl Gene', function () {
-      const params = _.assign( {}, baseParams, { 'target': NS_ENSEMBL } );
+      const params = _.assign( {}, baseParams, { 'targetDb': NS_ENSEMBL } );
       const result = createGConvertOpts( params );
       expect( result.target ).to.equal( GPROFILER_NS_MAP.get(NS_ENSEMBL) );
     });
 
     it ('should return to correct object with default options', function () {
-      const result = createGConvertOpts( _.assign( {}, defaultOptions, {query: query1}) );
+      const result = createGConvertOpts( { query: query1 } );
       const expected = _.assign( {}, defaultOptions, {
-        query: query1,
-        target: GPROFILER_NS_MAP.get(NS_HGNC)
+        query: query1
       });
       expect( result ).to.deep.equal( expected );
     });
 
     it ('should return to correct object with user options', function () {
-      const result = createGConvertOpts( _.assign( {}, defaultOptions, {query: query1}, userOptions) );
+      const result = createGConvertOpts( _.assign( { query: query1 }, userOptions ) );
       const expected = _.assign( {}, defaultOptions, {
         query: query1,
         target: GPROFILER_NS_MAP.get(NS_HGNC_SYMBOL)
@@ -105,8 +103,8 @@ describe ('Enrichment service: validation', function () {
     });
 
     it ('should throw error with invalid user options', function () {
-      expect( () => createGConvertOpts( _.assign( {}, defaultOptions, { query: query1 }, { target: 'bloat' } ) ) ).to.throw ( InvalidParamError );
-      expect( () => createGConvertOpts( _.assign( {}, defaultOptions,  { query: '' } ) ) ).to.throw ( InvalidParamError );
+      expect( () => createGConvertOpts( _.assign( {}, { query: query1 }, { targetDb: 'bloat' } ) ) ).to.throw ( InvalidParamError );
+      expect( () => createGConvertOpts( _.assign( {}, { query: '' } ) ) ).to.throw ( InvalidParamError );
     });
   });
 


### PR DESCRIPTION
Renamed the target database parameter selection to `namespace` and made it optional; defaults this value to `hgnc`. 
Refs #1359