### PR TITLE
Enrichment checks for existing files before downloading

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -132,25 +132,17 @@ function onListening() {
   debug('Listening on ' + bind);
 }
 
-// for now disable db
-// let setUpDb = () => {
-//   let log = (...msg) => function( val ){ logger.debug( ...msg ); return val; };
-//   let access = name => db.accessTable( name );
-//   let setup = name => {
-//     return access( name )
-//       .then( log('Accessed table "%s"', name) )
-//       .then( log('Set up synching for "%s"', name) )
-//     ;
-//   };
+const { getPathwayInfoTable } = require('./routes/enrichment/visualization/pathway-table');
+let initEnrichment = async () => {
+  await getPathwayInfoTable();
+};
 
-//   return Promise.all( ['pathways'].map( setup ) );
-// };
+let initRoutes = async () => Promise.all([
+    initEnrichment()
+  ]); 
 
-// for now disable db stuff...
-let setUpDb = () => {};
-
-// set up rethinkdb
-Promise.try( setUpDb ).then( () => {
+// set up routes 
+Promise.try( initRoutes ).then( () => {
   server.listen(port);
 } );
 

--- a/src/server/routes/enrichment/visualization/update-enrichment.js
+++ b/src/server/routes/enrichment/visualization/update-enrichment.js
@@ -1,11 +1,15 @@
 const _ = require('lodash');
 const fs = require('fs');
+const path = require('path');
 const Promise = require('bluebird');
+const sanitize = require("sanitize-filename");
 
 const logger = require('../../../logger');
 const stat = Promise.promisify(fs.stat);
 const { writeArchiveFiles } = require('../../../source-files');
-const { GMT_ARCHIVE_URL } = require('../../../../config.js');
+const { GMT_ARCHIVE_URL, DOWNLOADS_FOLDER_NAME } = require('../../../../config.js');
+const ROOT_FOLDER_PATH = path.resolve( __dirname, '../../../../../' );
+const DOWNLOADS_FOLDER_PATH = path.resolve( ROOT_FOLDER_PATH, DOWNLOADS_FOLDER_NAME );
 
 const GMT_ARCHIVE_FILENAMES = [
   'hsapiens.GO/BP.name.gmt',
@@ -33,13 +37,20 @@ const sourceFilePaths = p => {
 
 const updateEnrichment = async () => {
   try {
-    fpaths = await writeArchiveFiles( GMT_ARCHIVE_URL, GMT_ARCHIVE_FILENAMES );
-    const fileStats = await stat( _.head( fpaths ) );
+    // If exists in DOWNLOADS_FOLDER_PATH
+    const sanitized_filenames = GMT_ARCHIVE_FILENAMES.map( sanitize );
+    const fileStats = await stat( path.resolve( DOWNLOADS_FOLDER_PATH, _.head( sanitized_filenames ) ) );
+    sourceFilePaths( sanitized_filenames.map( fname => path.resolve( DOWNLOADS_FOLDER_PATH, fname ) ) );
     lastModTime( fileStats.mtimeMs );
-    logger.info( `Enrichment sources updated` );
+
   } catch (e) {
-    logger.error( `A problem was encountered in updateEnrichment: ${e}` );
-    throw e;
+    // Populate source files
+    sourceFilePaths( await writeArchiveFiles( GMT_ARCHIVE_URL, GMT_ARCHIVE_FILENAMES ) );
+    const fileStats = await stat( _.head( sourceFilePaths() ) );
+    lastModTime( fileStats.mtimeMs );
+
+  } finally {
+    logger.info(`Enrichment data updated`);
   }
 };
 


### PR DESCRIPTION
- Add code that initializes (enrichment) module before server listening
- Enrichment update module checks for already downloaded GMT files (i.e. this would happen say in development) before going to g:Profiler to download them. On a fresh install, this would result in  fresh GMT files. 

refs #1378 #1373
