### PR TITLE
Escape special characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6262,6 +6262,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "lucene-escape-query": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lucene-escape-query/-/lucene-escape-query-1.0.1.tgz",
+      "integrity": "sha512-iuB/RqAZjHI9YWm3zyM8qQkPxCi5nA3zcYZn71UM/W/+wh26fWpfxkLKZSgogoAvBjhN/4NhR+hxk2gScc81ow=="
+    },
     "macaddress": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.9.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "fready": "^1.0.0",
     "hyperscript": "^2.0.2",
     "lodash": "^4.17.4",
+    "lucene-escape-query": "^1.0.1",
     "mem": "^4.0.0",
     "morgan": "^1.9.0",
     "mousetrap": "^1.6.2",

--- a/src/server/routes/search/search.js
+++ b/src/server/routes/search/search.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const luceneEscapeQuery = require('lucene-escape-query');
 
 const { NS_NCBI_GENE, NS_HGNC_SYMBOL, NS_UNIPROT } = require('../../../config');
 
@@ -21,7 +22,10 @@ const idFromXrefs = ( xrefLinks, namespace ) => {
   return xref ? _.last( _.compact( xref.uri.split('/') ) ) : undefined;
 };
 
-const sanitize = ( rawQuery, maxLength = QUERY_MAX_CHARS ) => rawQuery.trim().substring( 0, maxLength );
+const sanitize = ( rawQuery, maxLength = QUERY_MAX_CHARS ) => {
+  const escape = raw => luceneEscapeQuery.escape( raw );
+  return escape( rawQuery.trim().substring( 0, maxLength ) );
+};
 const splitOnWhitespace = tokens => _.flatten( tokens.map( t => t.split(/\s+/) ) );
 const splitOnCommas = queryString => queryString.split(/,/).map( t => t.trim() );
 const dropQuotes = tokens => tokens.map( t => t.replace(/['"]/g, '') );

--- a/src/server/routes/search/search.js
+++ b/src/server/routes/search/search.js
@@ -23,7 +23,11 @@ const idFromXrefs = ( xrefLinks, namespace ) => {
 };
 
 const sanitize = ( rawQuery, maxLength = QUERY_MAX_CHARS ) => {
-  const escape = raw => luceneEscapeQuery.escape( raw );
+  const escape = raw => {
+    let escaped = luceneEscapeQuery.escape( raw );
+    escaped = escaped.replace(/\//g, '\\/');
+    return escaped;
+  };
   return escape( rawQuery.trim().substring( 0, maxLength ) );
 };
 const splitOnWhitespace = tokens => _.flatten( tokens.map( t => t.split(/\s+/) ) );


### PR DESCRIPTION
This [lucene-escape-query](https://www.npmjs.com/package/lucene-escape-query) seems to take care of most cases that break the pc server. However, doesn't appear to escape slashes so things like `AKT/AMPK` return nothing unlike `AKT\/AMPK`. 

Refs #1409