### PR TITLE
App card should linkify the sliding panel for interactions & enrichment.

### DIFF
--- a/src/client/common/components/app-card.js
+++ b/src/client/common/components/app-card.js
@@ -8,7 +8,7 @@ class AppCard extends React.Component {
   }
 
   render(){
-    let { enabled, hint, url, image, imageClass, title, body } = this.props;
+    let { enabled, hint, url, image, imageClass, title, body, linkifyContent } = this.props;
 
     return h('.app-card', {
         className: classNames({ 'app-card-disabled': !enabled })
@@ -24,12 +24,17 @@ class AppCard extends React.Component {
           })
         }, [ image ])
       ]),
-      h('div.app-card-content', [
-        h( 'div.app-card-header', [
-          h( 'h4.app-card-title', [title] ),
-          h( 'span.app-card-hint', [hint] )
-        ]),
-        h( 'div.app-card-body', [body] )
+      h('a.app-card-content-link', linkifyContent ? {
+        href: url,
+        target: '_blank'
+      } : {}, [
+        h('div.app-card-content', [
+          h( 'div.app-card-header', [
+            h( 'h4.app-card-title', [title] ),
+            h( 'span.app-card-hint', [hint] )
+          ]),
+          h( 'div.app-card-body', [body] )
+        ])
       ])
     ]);
   }

--- a/src/client/features/search/gene-results-view.js
+++ b/src/client/features/search/gene-results-view.js
@@ -47,7 +47,7 @@ class GeneResultsView extends React.Component {
     let title = 'Enrichment';
     let body = 'Explore a network of pathways that contain genes identified in your query.';
 
-    return { enabled, hint, url, imageClass, title, body };
+    return { enabled, hint, url, imageClass, title, body, linkifyContent: true };
   }
 
   getInteractionsAppInfo( geneResults, searchString ){
@@ -59,7 +59,7 @@ class GeneResultsView extends React.Component {
     let title = 'Interactions';
     let body = 'Visualize interactions between the genes identified in your query.';
 
-    return { enabled, hint, url, imageClass, title, body };
+    return { enabled, hint, url, imageClass, title, body, linkifyContent: true };
   }
 
   render(){


### PR DESCRIPTION
> B. App Card
> When no hyperlinks appear within sliding panel (on hover), the panel effectively blocks one from navigating to the target site (e.g. the interactions, enrichment)

The feature / Biofactoid card should be unaffected.

Ref: Component tweaks #1415 (B)