### PR TITLE
Pathway link: Article and data provider

### DIFF
--- a/src/client/features/pathways/index.js
+++ b/src/client/features/pathways/index.js
@@ -16,6 +16,7 @@ const { stylesheet, bindCyEvents, PATHWAYS_LAYOUT_OPTS } = require('./cy');
 const { TimeoutError } = require('../../../util');
 const { ErrorMessage } = require('../../common/components/error-message');
 const { Contribute } = require('../../common/components/contribute');
+const PathwayTitle = require('./pathway-title');
 
 class Pathways extends React.Component {
   constructor(props) {
@@ -87,10 +88,7 @@ class Pathways extends React.Component {
     let appBar = h('div.app-bar', [
       h('div.app-bar-branding', [
         h(PcLogoLink),
-        h('div.app-bar-title', [
-          h('span', pathway.name() + ' | '),
-          h('a.plain-link', { href: pathway.datasourceUrl(), target: '_blank' }, ' ' + pathway.datasource())
-        ])
+        h(PathwayTitle, { pathway })
       ]),
       h(PathwaysToolbar, { cySrv, pathway, downloadOpts }),
       h(Contribute, { text: 'Add my pathway' })

--- a/src/client/features/pathways/pathway-title.js
+++ b/src/client/features/pathways/pathway-title.js
@@ -47,7 +47,6 @@ class PathwayTitle extends React.Component {
   getName(){
     // Crapshoot whether a DB has a resolvable URL or not
     const DB_PREFIX_2_URL_TEMPLATE = new Map([
-      ['biocyc', `${IDENTIFIERS_URL}/biocyc:`],
       ['biofactoid', `${IDENTIFIERS_URL}/biofactoid:`],
       ['panther.pathway', `${IDENTIFIERS_URL}/panther.pathway:`],
       ['smpdb', `${IDENTIFIERS_URL}/smpdb:`],

--- a/src/client/features/pathways/pathway-title.js
+++ b/src/client/features/pathways/pathway-title.js
@@ -1,21 +1,10 @@
 const React = require('react');
 const h = require('react-hyperscript');
+const _ = require('lodash');
+
 const { ServerAPI } = require('../../services');
-// const _ = require('lodash');
 
-// const { ServerAPI } = require('../../services');
-// const { NS_CHEBI, NS_ENSEMBL, NS_HGNC, NS_HGNC_SYMBOL, NS_NCBI_GENE, NS_PUBMED, NS_REACTOME, NS_UNIPROT } = require('../../../config');
-
-// const DEFAULT_NUM_NAMES = 3;
-// const SUPPORTED_COLLECTIONS = new Map([
-//   [NS_CHEBI, 'ChEBI'],
-//   [NS_ENSEMBL, 'Ensembl'],
-//   [NS_HGNC, 'HGNC'],
-//   [NS_HGNC_SYMBOL, 'HGNC'],
-//   [NS_NCBI_GENE, 'NCBI Gene'],
-//   [NS_REACTOME, 'Reactome'],
-//   [NS_UNIPROT, 'UniProt']
-// ]);
+const { DOI_BASE_URL, IDENTIFIERS_URL, PUBMED_BASE_URL } = require( '../../../config.js' );
 
 // A component that displays a pathway title
 // props:
@@ -23,39 +12,93 @@ const { ServerAPI } = require('../../services');
 class PathwayTitle extends React.Component {
   constructor(props){
     super(props);
-    const { pathway } = this.props;
 
     this.state = {
-      name: pathway.name(),
       publications: []
     };
   }
 
+  /**
+   * Supports PublicationXrefs from PubMed; in principle, could be any source (e.g. bioRxiv).
+   * @returns {Promise<Array>} - Array of publication objects
+   */
   async loadPublications(){
+    const normalizePubmedRecord = record => {
+      const { source: journal, date, firstAuthor, doi, pubmed  } = record;
+      return { journal, date, firstAuthor, doi, pubmed };
+    };
     const MAX_PUBS = 10;
     const isPubmedXref = ({ db }) => db === 'pubmed';
     const { pathway } = this.props;
     const pubmedIds = pathway.publicationXrefs().slice( 0, MAX_PUBS ).filter( isPubmedXref ).map( ({ id }) => id );
     try {
-      const publications = await ServerAPI.getPubmedPublications( pubmedIds );
-      this.setState({ publications });
+      return ServerAPI.getPubmedPublications( pubmedIds ).map( normalizePubmedRecord );
     } catch( err ){
       // Swallow error
     }
   }
 
-  componentDidMount(){
-    return this.loadPublications();
+  async componentDidMount(){
+    const publications = await this.loadPublications();
+    return new Promise(resolve => this.setState({ publications }, () => resolve( publications )));
+  }
+
+  // Enhance the name with a link to a source page if possible
+  getName(){
+    // Crapshoot whether a DB has a resolvable URL or not
+    const DB_PREFIX_2_URL_TEMPLATE = new Map([
+      ['biocyc', `${IDENTIFIERS_URL}/biocyc:`],
+      ['biofactoid', `${IDENTIFIERS_URL}/biofactoid:`],
+      ['panther.pathway', `${IDENTIFIERS_URL}/panther.pathway:`],
+      ['smpdb', `${IDENTIFIERS_URL}/smpdb:`],
+      ['reactome', `${IDENTIFIERS_URL}/reactome:`]
+    ]);
+    const isSupportedDb = ({ db }) => DB_PREFIX_2_URL_TEMPLATE.has( db );
+    const { pathway } = this.props;
+    let name = pathway.name();
+
+    let uniXrefs = pathway.unificationXrefs();
+    if( !_.isEmpty( uniXrefs ) ){
+      uniXrefs = uniXrefs.filter( isSupportedDb );
+      if( uniXrefs.length ){
+        const { db, id } = _.first( uniXrefs );
+        const baseUrl = DB_PREFIX_2_URL_TEMPLATE.get( db );
+        const href = `${baseUrl}${id}`;
+        name = [ h('a.highlight-link', { href, target: '_blank' }, name) ];
+      }
+    }
+
+    return name;
+  }
+
+  // Add an article link when directly relevant to pathway (i.e. Biofactoid!)
+  getSource(){
+    const ARTICLE_SUPPORTED_DATASOURCES = new Set([ 'Biofactoid' ]);
+    const { pathway } = this.props;
+    const { publications } = this.state;
+    const datasource = pathway.datasource();
+    let source = [ h('a', { href: pathway.datasourceUrl(), target: '_blank' }, ' ' + datasource ) ];
+
+    if( ARTICLE_SUPPORTED_DATASOURCES.has( datasource ) && publications.length ){
+      const { journal, date, firstAuthor, doi, pubmed } = _.first( publications );
+      const author = h('span', ` ${firstAuthor} et al.`);
+      const reference = h( doi ? 'a.plain-link' : 'span', doi ? { href: `${DOI_BASE_URL}${doi}`, target: '_blank' } : null, `${journal} ${date}` );
+      source.push( h('span', ' | '), author, ' ', reference );
+      if( pubmed ){
+        const pubmedLink = h('a.plain-link', { href: `${PUBMED_BASE_URL}${pubmed}`, target: '_blank' }, 'PubMed' );
+        source.push( ' · ', pubmedLink );
+      }
+    }
+    return source;
   }
 
   render(){
-    const { pathway } = this.props;
-    const { name, publications } = this.state;
-    console.log( publications );
+    let name = this.getName();
+    let source = this.getSource();
 
     return h('div.pathway-title', [
       h('div.pathway-title-name', name ),
-      h('div.pathway-title-source', [ h('a.plain-link', { href: pathway.datasourceUrl(), target: '_blank' }, ' ' + pathway.datasource()) ])
+      h('div.pathway-title-source', source )
     ]);
   }
 }

--- a/src/client/features/pathways/pathway-title.js
+++ b/src/client/features/pathways/pathway-title.js
@@ -1,0 +1,64 @@
+const React = require('react');
+const h = require('react-hyperscript');
+const { ServerAPI } = require('../../services');
+// const _ = require('lodash');
+
+// const { ServerAPI } = require('../../services');
+// const { NS_CHEBI, NS_ENSEMBL, NS_HGNC, NS_HGNC_SYMBOL, NS_NCBI_GENE, NS_PUBMED, NS_REACTOME, NS_UNIPROT } = require('../../../config');
+
+// const DEFAULT_NUM_NAMES = 3;
+// const SUPPORTED_COLLECTIONS = new Map([
+//   [NS_CHEBI, 'ChEBI'],
+//   [NS_ENSEMBL, 'Ensembl'],
+//   [NS_HGNC, 'HGNC'],
+//   [NS_HGNC_SYMBOL, 'HGNC'],
+//   [NS_NCBI_GENE, 'NCBI Gene'],
+//   [NS_REACTOME, 'Reactome'],
+//   [NS_UNIPROT, 'UniProt']
+// ]);
+
+// A component that displays a pathway title
+// props:
+// - pathway: Model instance
+class PathwayTitle extends React.Component {
+  constructor(props){
+    super(props);
+    const { pathway } = this.props;
+
+    this.state = {
+      name: pathway.name(),
+      publications: []
+    };
+  }
+
+  async loadPublications(){
+    const MAX_PUBS = 10;
+    const isPubmedXref = ({ db }) => db === 'pubmed';
+    const { pathway } = this.props;
+    const pubmedIds = pathway.publicationXrefs().slice( 0, MAX_PUBS ).filter( isPubmedXref ).map( ({ id }) => id );
+    try {
+      const publications = await ServerAPI.getPubmedPublications( pubmedIds );
+      this.setState({ publications });
+    } catch( err ){
+      // Swallow error
+    }
+  }
+
+  componentDidMount(){
+    return this.loadPublications();
+  }
+
+  render(){
+    const { pathway } = this.props;
+    const { name, publications } = this.state;
+    console.log( publications );
+
+    return h('div.pathway-title', [
+      h('div.pathway-title-name', name ),
+      h('div.pathway-title-source', [ h('a.plain-link', { href: pathway.datasourceUrl(), target: '_blank' }, ' ' + pathway.datasource()) ])
+    ]);
+  }
+}
+
+
+module.exports = PathwayTitle;

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ let defaults = {
   IDENTIFIERS_URL: 'http://bioregistry.io',
   NCBI_EUTILS_BASE_URL: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils',
   NCBI_API_KEY: 'b99e10ebe0f90d815a7a99f18403aab08008', // for dev testing only (baderlabsysmonitor ncbi key)
+  PUBMED_BASE_URL: 'https://pubmed.ncbi.nlm.nih.gov/',
   HGNC_BASE_URL: 'https://rest.genenames.org',
   UNIPROT_API_BASE_URL: 'https://www.ebi.ac.uk/proteins/api',
   DOI_BASE_URL: 'https://doi.org/',

--- a/src/models/pathway/pathway-model.js
+++ b/src/models/pathway/pathway-model.js
@@ -27,7 +27,7 @@ class Pathway {
   }
 
   name(){
-    return _.get(this.raw, 'graph.pathwayMetadata.title.0', '');
+    return _.get(this.raw, 'graph.pathwayMetadata.title', '');
   }
 
   datasource(){

--- a/src/models/pathway/pathway-model.js
+++ b/src/models/pathway/pathway-model.js
@@ -52,6 +52,10 @@ class Pathway {
     return _.uniq(names);
   }
 
+  publicationXrefs(){
+    return _.get( this.raw, 'graph.pathwayMetadata.pubXrefs' );
+  }
+
 }
 
 module.exports = Pathway;

--- a/src/models/pathway/pathway-model.js
+++ b/src/models/pathway/pathway-model.js
@@ -56,6 +56,10 @@ class Pathway {
     return _.get( this.raw, 'graph.pathwayMetadata.pubXrefs' );
   }
 
+  unificationXrefs(){
+    return _.get( this.raw, 'graph.pathwayMetadata.uniXrefs' );
+  }
+
 }
 
 module.exports = Pathway;

--- a/src/server/routes/pathways/generate-pathway-json/biopax-metadata/index.js
+++ b/src/server/routes/pathways/generate-pathway-json/biopax-metadata/index.js
@@ -43,13 +43,13 @@ let extractBiopaxMetadata = ( biopaxJsonEntry, physicalEntityData ) => {
   };
 };
 
-// transform biopaxJsonText into a consolidated js object
-let biopaxText2ElementMap = async ( biopaxJsonText, xrefSuggester ) => {
+// transform biopaxJson into a consolidated js object
+let biopaxText2ElementMap = async ( biopaxJson, xrefSuggester ) => {
   let rawMap = new Map();
   let elementMap = new Map();
   let xRefMap = new Map();
 
-  let biopaxElementGraph = JSON.parse(biopaxJsonText)['@graph'];
+  let biopaxElementGraph = biopaxJson['@graph'];
   let externalReferences = [];
 
   biopaxElementGraph.forEach( element => {
@@ -115,10 +115,10 @@ let biopaxText2ElementMap = async ( biopaxJsonText, xrefSuggester ) => {
 };
 
 
-let fillInBiopaxMetadata = async ( cyJsonEles, biopaxJsonText ) => {
+let fillInBiopaxMetadata = async ( cyJsonEles, biopaxJson ) => {
   let nodes = cyJsonEles.nodes;
 
-  let bm = await biopaxText2ElementMap( biopaxJsonText, xref2Uri );
+  let bm = await biopaxText2ElementMap( biopaxJson, xref2Uri );
   let physicalEntityData = await getGenericPhyiscalEntityData( nodes );
 
   nodes.forEach( node => {

--- a/src/server/routes/pathways/generate-pathway-json/index.js
+++ b/src/server/routes/pathways/generate-pathway-json/index.js
@@ -47,14 +47,14 @@ function getPathwayMetadata(uri) {
     get('Entity/dataSource/displayName'),
     get('Entity/comment'),
     get('Pathway/organism/displayName'),
-    pcServices.getDataSources() 
+    pcServices.getDataSources()
   ])
   .then( ([ title, dataSource, comments, organism, supportedProviders ]) => {
     const supportedProvider = supportedProviders.find( supportedProvider => supportedProvider.alias.some( alias => alias === _.head( dataSource ) ) );
-    return { 
-      title, 
-      dataSource: _.get( supportedProvider, 'name' ), 
-      comments, 
+    return {
+      title: _.head( title ),
+      dataSource: _.get( supportedProvider, 'name' ),
+      comments,
       organism,
       urlToHomepage: _.get( supportedProvider, 'homepageUrl' )
     };

--- a/src/server/routes/pathways/generate-pathway-json/index.js
+++ b/src/server/routes/pathways/generate-pathway-json/index.js
@@ -38,13 +38,13 @@ const fillInBiopaxMetadataInThread = (nodes, biopaxJson) => {
 //Requires a valid pathway uri
 function getPathwayMetadata( uri, biopaxJson ) {
 
-  const getPathwayPubXrefs = ( pubXrefUris = [] )=> {
+  const getPathwayXrefs = ( uris = [] )=> {
     const graph = biopaxJson['@graph'];
-    const getPubXref = uri => {
+    const getXref = uri => {
       const { db, id } = _.find(graph, { '@id': uri });
       return { db, id };
     };
-    return pubXrefUris.map( getPubXref );
+    return uris.map( getXref );
   };
 
   // let title, dataSource, comments, organism, supportedProviders;
@@ -57,11 +57,13 @@ function getPathwayMetadata( uri, biopaxJson ) {
     get('Entity/comment'),
     get('Pathway/organism/displayName'),
     pcServices.getDataSources(),
-    get('Pathway/xref:PublicationXref')
+    get('Pathway/xref:PublicationXref'),
+    get('Pathway/xref:UnificationXref')
   ])
-  .then( ([ title, dataSource, comments, organism, supportedProviders, pubXrefUris ]) => {
+  .then( ([ title, dataSource, comments, organism, supportedProviders, pubXrefUris, uniXrefUris ]) => {
     const supportedProvider = supportedProviders.find( supportedProvider => supportedProvider.alias.some( alias => alias === _.head( dataSource ) ) );
-    const pubXrefs = getPathwayPubXrefs( pubXrefUris );
+    const pubXrefs = getPathwayXrefs( pubXrefUris );
+    const uniXrefs = getPathwayXrefs( uniXrefUris );
 
     return {
       uri,
@@ -70,7 +72,8 @@ function getPathwayMetadata( uri, biopaxJson ) {
       comments,
       organism,
       urlToHomepage: _.get( supportedProvider, 'homepageUrl' ),
-      pubXrefs
+      pubXrefs,
+      uniXrefs
     };
   });
 }

--- a/src/styles/common/app-bar.css
+++ b/src/styles/common/app-bar.css
@@ -25,12 +25,12 @@
   border-radius: 0.25em 0.25em 0 0;
 }
 
-.app-bar-title {
+/* .app-bar-title {
   color: var(--dark-base-colour);
   font-weight: bold;
   font-size: 0.9em;
   max-width: 95vw;
-}
+} */
 
 .app-toolbar {
   display: flex; /* use inline-flex if you want the bar to take up only the width of its children */

--- a/src/styles/common/pc-logo-link.css
+++ b/src/styles/common/pc-logo-link.css
@@ -1,6 +1,6 @@
 .pc-logo {
-  height: 30px;
-  width: 30px;
+  height: 50px;
+  width: 50px;
   background-image: url("../image/pc_logo_dark.svg");
 }
 

--- a/src/styles/features/pathways.css
+++ b/src/styles/features/pathways.css
@@ -7,14 +7,21 @@
 
 .pathway-title {
   max-width: 95vw;
-  line-height: 1.25em;
   margin: 0.25em;
 }
 
 .pathway-title .pathway-title-name {
-  font-size: 1.1em;
+  font-size: 1.2em;
+  font-weight: bold;
+  padding: 0.15em;
+
+  & .highlight-link {
+    color: rgb(26, 117, 215);
+  }
 }
 
 .pathway-title .pathway-title-source {
-  font-size: 0.9em;
+  font-size: 1em;
+  padding: 0.15em;
+
 }

--- a/src/styles/features/pathways.css
+++ b/src/styles/features/pathways.css
@@ -4,3 +4,17 @@
   position: relative;
   overflow: hidden;
 }
+
+.pathway-title {
+  max-width: 95vw;
+  line-height: 1.25em;
+  margin: 0.25em;
+}
+
+.pathway-title .pathway-title-name {
+  font-size: 1.1em;
+}
+
+.pathway-title .pathway-title-source {
+  font-size: 0.9em;
+}

--- a/test/server/pathways/pathways-network-generation.js
+++ b/test/server/pathways/pathways-network-generation.js
@@ -73,24 +73,25 @@ describe('Pathways route', function(){
   });
 
   describe('biopaxText2ElementMap', function(){
-    let biopaxJsonText;
+    let biopaxJson;
 
     before( () => {
-      biopaxJsonText = fs.readFileSync( path.resolve( __dirname, './sample-biopax-data.json' ), 'utf-8');
+      const str = fs.readFileSync( path.resolve( __dirname, './sample-biopax-data.json' ), 'utf-8');
+      biopaxJson = JSON.parse( str );
     });
 
     it('Should call the xrefSuggested dependency', async () => {
-      await biopaxText2ElementMap( biopaxJsonText, xref2UriStub );
+      await biopaxText2ElementMap( biopaxJson, xref2UriStub );
       expect( xref2UriStub.called ).to.be.true;
     });
 
     it('Should return populated Map', async () => {
-      const elementMap = await biopaxText2ElementMap( biopaxJsonText, xref2UriStub );
+      const elementMap = await biopaxText2ElementMap( biopaxJson, xref2UriStub );
       expect( elementMap.size ).to.be.at.least(1);
-    });  
+    });
 
     it('Should return Map value with correct properties', async () => {
-      const elementMap = await biopaxText2ElementMap( biopaxJsonText, xref2UriStub );
+      const elementMap = await biopaxText2ElementMap( biopaxJson, xref2UriStub );
       const mapValue = elementMap.get( MAP_ELEMENT_KEY );
       expect( mapValue ).to.exist;
       expect( mapValue ).to.have.property('@id');
@@ -101,7 +102,7 @@ describe('Pathways route', function(){
       expect( mapValue ).to.have.property('entityReference');
       expect( mapValue ).to.have.property('name');
       expect( mapValue ).to.have.property('xref');
-    });  
+    });
   }); // biopaxText2ElementMap
 
   describe('extractBiopaxMetadata', function(){
@@ -115,7 +116,7 @@ describe('Pathways route', function(){
       expect( metadata ).to.have.property('standardName');
       expect( metadata ).to.have.property('displayName');
       expect( metadata ).to.have.property('xrefLinks');
-    });  
+    });
   }); // extractBiopaxMetadata
 });
 


### PR DESCRIPTION
The goal here was to provide richer links from the pathway to the underlying source and evidence.

- Updates the Pathway viewer with a `PathwayTitle` component that provides:
  - A link from the pathway name to the datasource landing page (when available)
  - A reference to the article, when there is a direct relationship (i.e. biofactoid) 
- Other
  - Refactoring `generate-pathway-json` (async/await)

Refs #1407 

## Examples

### Data source and article links

<img width="500" alt="Screenshot 2024-06-18 at 2 45 55 PM" src="https://github.com/PathwayCommons/app-ui/assets/4706307/f9622421-f411-4115-84de-b03e6c35560a">

### Data source link

<img width="500" alt="Screenshot 2024-06-18 at 2 48 26 PM" src="https://github.com/PathwayCommons/app-ui/assets/4706307/34cdb676-3845-49cc-bd4e-6c2e1086e998">


### Default

<img width="500" alt="Screenshot 2024-06-18 at 2 49 07 PM" src="https://github.com/PathwayCommons/app-ui/assets/4706307/81524ffe-6166-4a30-a0ed-36c288f53944">
