### PR TITLE
Manually create xref links

### DIFF
--- a/src/server/external-services/gprofiler/gconvert/index.js
+++ b/src/server/external-services/gprofiler/gconvert/index.js
@@ -11,7 +11,7 @@ const GCONVERT_URL = GPROFILER_URL + 'api/convert/convert/';
 const GPROFILER_NS_MAP = new Map([
   [NS_HGNC, 'HGNC_ACC'],
   [NS_HGNC_SYMBOL, 'HGNC'],
-  [NS_UNIPROT, 'UNIPROTSWISSPROT'],
+  [NS_UNIPROT, 'UNIPROTSWISSPROT_ACC'],
   [NS_NCBI_GENE, 'ENTREZGENE_ACC'],
   [NS_ENSEMBL, 'ENSG']
 ]);
@@ -30,7 +30,7 @@ const createGConvertOpts = opts => {
   const target = GPROFILER_NS_MAP.get(  _.get( opts, ['namespace'], defaults.target ) );
   const query = _.get( opts, ['query'] );
   let gConvertOpts = _.assign( {}, defaults, { query, target } );
-  
+
   if( !Array.isArray( query ) ){
     throw new InvalidParamError( `Error creating gconvert request - expected an array of strings for "query", got ${query}`);
   }
@@ -38,7 +38,7 @@ const createGConvertOpts = opts => {
   if( target == null ){
     throw new InvalidParamError( `Error creating gconvert request - expected a valid "namespace", got ${target}`);
   }
-  
+
   return gConvertOpts;
 };
 

--- a/src/server/external-services/pathway-commons.js
+++ b/src/server/external-services/pathway-commons.js
@@ -295,7 +295,7 @@ const formatXrefQuery = ( name, localId ) => _.concat( [], { db: name, id: local
  * given the identifiers collection name and identifier of a bio entity;
  * @return { object } the URL origin and namespace
  */
-const fetchEntityUriBase = ( name, localId ) => { // eslint-disable-line
+const fetchEntityUriBase = ( name, localId ) => {
   const url = config.PC_URL + "validate/xref";
   const fetchOpts = {
     method: 'POST',

--- a/src/server/external-services/pathway-commons.js
+++ b/src/server/external-services/pathway-commons.js
@@ -10,7 +10,7 @@ const { cachePromise } = require('../cache');
 const { fetch } = require('../../util');
 const logger = require('../logger');
 const config = require('../../config');
-const { uri2filename } = require('../../util/uri.js');
+const { uri2filename, fromXref } = require('../../util/uri.js');
 
 const xrefCache = new QuickLRU({ maxSize: config.PC_CACHE_MAX_SIZE });
 const queryCache = new QuickLRU({ maxSize: config.PC_CACHE_MAX_SIZE });
@@ -295,7 +295,7 @@ const formatXrefQuery = ( name, localId ) => _.concat( [], { db: name, id: local
  * given the identifiers collection name and identifier of a bio entity;
  * @return { object } the URL origin and namespace
  */
-const fetchEntityUriBase = ( name, localId ) => {
+const fetchEntityUriBase = ( name, localId ) => { // eslint-disable-line
   const url = config.PC_URL + "validate/xref";
   const fetchOpts = {
     method: 'POST',
@@ -314,7 +314,7 @@ const fetchEntityUriBase = ( name, localId ) => {
     });
 };
 
-const getEntityUriParts = cachePromise(fetchEntityUriBase, xrefCache, name => name);
+const getEntityUriParts = cachePromise(fetchEntityUriBase, xrefCache, name => name); // eslint-disable-line
 
 /*
  * xref2Uri
@@ -325,12 +325,17 @@ const getEntityUriParts = cachePromise(fetchEntityUriBase, xrefCache, name => na
  *
  * This could be updated to accept array of { name, localId } fields now....
  */
-const xref2Uri =  ( name, localId ) => {
-  return getEntityUriParts( name, localId )
-    .then( uriParts => ({
-      uri: uriParts.origin + '/' + uriParts.namespace + ':' + localId,
-      namespace: uriParts.namespace
-    }) );
+const xref2Uri = async ( name, localId ) => {
+  // Manually bypass service call
+  return ({
+    uri: fromXref( name, localId ),
+    namespace: name
+  });
+  // return getEntityUriParts( name, localId )
+  //   .then( uriParts => ({
+  //     uri: uriParts.origin + '/' + uriParts.namespace + ':' + localId,
+  //     namespace: uriParts.namespace
+  //   }) );
 };
 
 module.exports = { query, search: cachedSearch, sifGraph, xref2Uri, getDataSources };

--- a/src/server/routes/enrichment/visualization/generate-enrichment-network-json.js
+++ b/src/server/routes/enrichment/visualization/generate-enrichment-network-json.js
@@ -1,15 +1,15 @@
 const _ = require('lodash');
 
-// const { TimeoutError } = require('../../../../util');
+const { TimeoutError } = require('../../../../util');
 const logger = require('../../../logger');
 const { IDENTIFIERS_URL, NS_GENE_ONTOLOGY, NS_REACTOME } = require('../../../../config');
-// const { xref2Uri } = require('../../../external-services/pathway-commons');
+const { xref2Uri } = require('../../../external-services/pathway-commons');
 
 const isGOId = token => /^GO:\d+$/.test( token );
 const isReactomeId = token => /^R-HSA-\d+$/.test( token );
 const normalizeId = pathwayId => pathwayId.replace('REAC:', '');
 
-// const reThrow = error => { throw error; };
+const reThrow = error => { throw error; };
 const fallbackXref = ( namespace, record ) => ({ uri: IDENTIFIERS_URL + '/' + namespace + ':' + record, namespace });
 
 const getXref = id => {
@@ -17,15 +17,13 @@ const getXref = id => {
 
   if( isGOId( id ) ){
     name = NS_GENE_ONTOLOGY;
-    id = id.replace( 'GO:', '' );
+    id = id.replace('GO:', '');
   } else if ( isReactomeId( id ) ) {
     name = NS_REACTOME;
   }
-
-  return fallbackXref( name, id );
   // Try the service. Fallback to manually constructing xref if TimeoutError
-  // return xref2Uri( name, id )
-  //     .catch( error => error instanceof TimeoutError ? fallbackXref( name, id ): reThrow( error ) );
+  return xref2Uri( name, id )
+      .catch( error => error instanceof TimeoutError ? fallbackXref( name, id ): reThrow( error ) );
 };
 
 const createEnrichmentNetworkNode = pathway => {

--- a/src/server/routes/enrichment/visualization/generate-enrichment-network-json.js
+++ b/src/server/routes/enrichment/visualization/generate-enrichment-network-json.js
@@ -1,15 +1,15 @@
 const _ = require('lodash');
 
-const { TimeoutError } = require('../../../../util');
+// const { TimeoutError } = require('../../../../util');
 const logger = require('../../../logger');
 const { IDENTIFIERS_URL, NS_GENE_ONTOLOGY, NS_REACTOME } = require('../../../../config');
-const { xref2Uri } = require('../../../external-services/pathway-commons');
+// const { xref2Uri } = require('../../../external-services/pathway-commons');
 
 const isGOId = token => /^GO:\d+$/.test( token );
 const isReactomeId = token => /^R-HSA-\d+$/.test( token );
 const normalizeId = pathwayId => pathwayId.replace('REAC:', '');
 
-const reThrow = error => { throw error; };
+// const reThrow = error => { throw error; };
 const fallbackXref = ( namespace, record ) => ({ uri: IDENTIFIERS_URL + '/' + namespace + ':' + record, namespace });
 
 const getXref = id => {
@@ -17,12 +17,15 @@ const getXref = id => {
 
   if( isGOId( id ) ){
     name = NS_GENE_ONTOLOGY;
+    id = id.replace( 'GO:', '' );
   } else if ( isReactomeId( id ) ) {
     name = NS_REACTOME;
   }
+
+  return fallbackXref( name, id );
   // Try the service. Fallback to manually constructing xref if TimeoutError
-  return xref2Uri( name, id )
-      .catch( error => error instanceof TimeoutError ? fallbackXref( name, id ): reThrow( error ) );
+  // return xref2Uri( name, id )
+  //     .catch( error => error instanceof TimeoutError ? fallbackXref( name, id ): reThrow( error ) );
 };
 
 const createEnrichmentNetworkNode = pathway => {

--- a/src/server/routes/search/search.js
+++ b/src/server/routes/search/search.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 // const logger = require('../../logger');
 const url = require('url');
 const luceneEscapeQuery = require('lucene-escape-query');
-const { NS_NCBI_GENE, NS_HGNC_SYMBOL, NS_UNIPROT } = require('../../../config');
+const { NS_NCBI_GENE, NS_HGNC_SYMBOL, NS_UNIPROT, IDENTIFIERS_URL } = require('../../../config');
 const { getEntitySummary: getNcbiGeneSummary } = require('../../external-services/ncbi');
 const { validatorGconvert } = require('../../external-services/gprofiler/gconvert');
 const pc = require('../../external-services/pathway-commons');
@@ -52,9 +52,13 @@ const fillInXref = async ( summaries, ncbiAlias, uniprotAlias, name ) => {
     const eSummary = _.find( summaries, s => s.localId === ncbiGeneId );
     const hasUniProt = idFromXrefs( _.get( eSummary, 'xrefLinks' ), NS_UNIPROT );
     if ( eSummary && !hasUniProt ) {
-      // Use our internal service to grab the xref info
-      const xref = await pc.xref2Uri( name, _.get( uniprotAlias, token ) );
-      eSummary.xrefLinks.push( xref );
+      // TODO - duplicate function in ncbi.js
+      const createUri = ( namespace, localId ) => IDENTIFIERS_URL + '/' + namespace + ':' + localId;
+      const localId = uniprotAlias[ token ];
+      eSummary.xrefLinks.push({
+          namespace: name,
+          uri: createUri( name, localId )
+      });
     }
   }
 };

--- a/src/server/routes/search/search.js
+++ b/src/server/routes/search/search.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 // const logger = require('../../logger');
 const url = require('url');
 const luceneEscapeQuery = require('lucene-escape-query');
-const { NS_NCBI_GENE, NS_HGNC_SYMBOL, NS_UNIPROT, IDENTIFIERS_URL } = require('../../../config');
+const { NS_NCBI_GENE, NS_HGNC_SYMBOL, NS_UNIPROT } = require('../../../config');
 const { getEntitySummary: getNcbiGeneSummary } = require('../../external-services/ncbi');
 const { validatorGconvert } = require('../../external-services/gprofiler/gconvert');
 const pc = require('../../external-services/pathway-commons');
@@ -52,13 +52,9 @@ const fillInXref = async ( summaries, ncbiAlias, uniprotAlias, name ) => {
     const eSummary = _.find( summaries, s => s.localId === ncbiGeneId );
     const hasUniProt = idFromXrefs( _.get( eSummary, 'xrefLinks' ), NS_UNIPROT );
     if ( eSummary && !hasUniProt ) {
-      // TODO - duplicate function in ncbi.js
-      const createUri = ( namespace, localId ) => IDENTIFIERS_URL + '/' + namespace + ':' + localId;
-      const localId = uniprotAlias[ token ];
-      eSummary.xrefLinks.push({
-          namespace: name,
-          uri: createUri( name, localId )
-      });
+      // Use our internal service to grab the xref info
+      const xref = await pc.xref2Uri( name, _.get( uniprotAlias, token ) );
+      eSummary.xrefLinks.push( xref );
     }
   }
 };

--- a/src/util/uri.js
+++ b/src/util/uri.js
@@ -1,6 +1,12 @@
+const config = require('../config.js');
+
 // Create file safe names from a uri
 const uri2filename = s => s.replace(/[^a-z0-9]/gi, '_').toLowerCase();
 
+// create from xref
+const fromXref = ( namespace, localId ) => config.IDENTIFIERS_URL + '/' + namespace + ':' + localId;
+
 module.exports = {
-  uri2filename
+  uri2filename,
+  fromXref
 };


### PR DESCRIPTION
This quick-fix manually creates xrefs to entities that the Search UI displays as hyperlinks. It bypasses a downed pc.xref2uri web service call, that, in retrospect, appears unnecessary. 

Refs #1479 